### PR TITLE
fix: enable non-error logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -869,6 +869,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
+
+[[package]]
 name = "object"
 version = "0.36.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -885,6 +895,12 @@ name = "once_cell"
 version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "parking_lot_core"
@@ -1130,6 +1146,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1238,6 +1263,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+dependencies = [
+ "cfg-if",
+ "once_cell",
 ]
 
 [[package]]
@@ -1374,6 +1409,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
+dependencies = [
+ "nu-ansi-term",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -1415,6 +1476,7 @@ dependencies = [
  "env_logger",
  "lazy_static",
  "libloading",
+ "log",
  "regex",
  "ropey",
  "serde",
@@ -1422,6 +1484,7 @@ dependencies = [
  "streaming-iterator",
  "tokio",
  "tower-lsp",
+ "tracing-subscriber",
  "tree-sitter",
  "tree-sitter-query",
 ]
@@ -1467,6 +1530,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "version_check"
@@ -1706,6 +1775,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1713,6 +1798,12 @@ checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ dissimilar = "1.0.9"
 env_logger = "0.11.5"
 lazy_static = "1.5.0"
 libloading = "0.8.5"
+log = "0.4.22"
 regex = "1.11.0"
 ropey = "1.6.1"
 serde = "1.0.210"
@@ -17,6 +18,7 @@ serde_json = "1.0.132"
 streaming-iterator = "0.1.9"
 tokio = { version = "1.40.0", features = ["rt-multi-thread", "macros", "io-std"] }
 tower-lsp = "0.20.0"
+tracing-subscriber = "0.3.18"
 tree-sitter = { version = "0.24.4", features = ["std", "wasm"] }
 tree-sitter-query = { git = "https://github.com/tree-sitter-grammars/tree-sitter-query", rev = "d0d9126a9b80a0bb609acdf960d3f1613fc319db", version = "0.4.0" }
 


### PR DESCRIPTION
It's not entirely clear to me what was causing the previous logging implementation to have issues. Only logs with `MessageType::ERROR` would be logged (at least in neovim). This could be partially addressed by using a `tracing_subscriber` logger (as suggested here: https://github.com/ebkalderon/tower-lsp/issues/423). The server's logs would show up if the level was set to `TRACE`, but then so would every single message exchanged between the lsp client and server. Swapping out the calls to `self.client.log_message()` with the `log` crate's macros, as well as to the `tracing_subscriber` changes seems to remedy things. Log file after start up:

```log
[START][2024-11-17 23:44:15] LSP logging initiated
[ERROR][2024-11-17 23:44:15] .../vim/lsp/rpc.lua:764	"rpc"	"/home/lillis/projects/ts_query_ls/target/debug/ts_query_ls"	"stderr"	'2024-11-18T04:44:15.478760Z  INFO ts_query_ls: ts_query_ls initialize: InitializeParams { process_id: Some(240085), root_path: Some("/home/lillis/projects/grammars/tree-sitter-c"), root_uri: Some(Url { scheme: "file", cannot_be_a_base: false, username: "", password: None, host: None, port: None, path: "/home/lillis/projects/grammars/tree-sitter-c", query: None, fragment: None }), initialization_options: None, capabilities: ClientCapabilities { workspace: Some(WorkspaceClientCapabilities { apply_edit: Some(true), workspace_edit: Some(WorkspaceEditClientCapabilities { document_changes: None, resource_operations: Some([Rename, Create, Delete]), failure_handling: None, normalizes_line_endings: None, change_annotation_support: None }), did_change_configuration: Some(DynamicRegistrationClientCapabilities { dynamic_registration: Some(false) }), did_change_watched_files: Some(DidChangeWatchedFilesClientCapabilities { dynamic_registration: Some(false), relative_pattern_support: Some(true) }), symbol: Some(WorkspaceSymbolClientCapabilities { dynamic_registration: Some(false), symbol_kind: Some(SymbolKindCapability { value_set: Some([File, Module, Namespace, Package, Class, Method, Property, Field, Constructor, Enum, Interface, Function, Variable, Constant, String, Number, Boolean, Array, Object, Key, Null, EnumMember, Struct, Event, Operator, TypeParameter]) }), tag_support: None, resolve_support: None }), execute_command: None, workspace_folders: Some(true), configuration: Some(true), semantic_tokens: Some(SemanticTokensWorkspaceClientCapabilities { refresh_support: Some(true) }), code_lens: None, file_operations: None, inline_value: None, inlay_hint: Some(InlayHintWorkspaceClientCapabilities { refresh_support: Some(true) }), diagnostic: None }), text_document: Some(TextDocumentClientCapabilities { synchronization: Some(TextDocumentSyncClientCapabilities { dynamic_registration: Some(false), will_save: Some(true), will_save_wait_until: Some(true), did_save: Some(true) }), completion: Some(CompletionClientCapabilities { dynamic_registration: Some(false), completion_item: Some(CompletionItemCapability { snippet_support: Some(true), commit_characters_support: Some(false), documentation_format: Some([Markdown, PlainText]), deprecated_support: Some(true), preselect_support: Some(false), tag_support: Some(TagSupport { value_set: [Deprecated] }), insert_replace_support: None, resolve_support: Some(CompletionItemCapabilityResolveSupport { properties: ["additionalTextEdits"] }), insert_text_mode_support: None, label_details_support: None }), completion_item_kind: Some(CompletionItemKindCapability { value_set: Some([Text, Method, Function, Constructor, Field, Variable, Class, Interface, Module, Property, Unit, Value, Enum, Keyword, Snippet, Color, File, Reference, Folder, EnumMember, Constant, Struct, Event, Operator, TypeParameter]) }), context_support: Some(false), insert_text_mode: None, completion_list: Some(CompletionListCapability { item_defaults: Some(["editRange", "insertTextFormat", "insertTextMode", "data"]) }) }), hover: Some(HoverClientCapabilities { dynamic_registration: Some(true), content_format: Some([Markdown, PlainText]) }), signature_help: Some(SignatureHelpClientCapabilities { dynamic_registration: Some(false), signature_information: Some(SignatureInformationSettings { documentation_format: Some([Markdown, PlainText]), parameter_information: Some(ParameterInformationSettings { label_offset_support: Some(true) }), active_parameter_support: Some(true) }), context_support: None }), references: Some(DynamicRegistrationClientCapabilities { dynamic_registration: Some(false) }), document_highlight: Some(DynamicRegistrationClientCapabilities { dynamic_registration: Some(false) }), document_symbol: Some(DocumentSymbolClientCapabilities { dynamic_registration: Some(false), symbol_kind: Some(SymbolKindCapability { value_set: Some([File, Module, Namespace, Package, Class, Method, Property, Field, Constructor, Enum, Interface, Function, Variable, Constant, String, Number, Boolean, Array, Object, Key, Null, EnumMember, Struct, Event, Operator, TypeParameter]) }), hierarchical_document_symbol_support: Some(true), tag_support: None }), formatting: Some(DynamicRegistrationClientCapabilities { dynamic_registration: Some(true) }), range_formatting: Some(DynamicRegistrationClientCapabilities { dynamic_registration: Some(true) }), on_type_formatting: None, declaration: Some(GotoCapability { dynamic_registration: None, link_support: Some(true) }), definition: Some(GotoCapability { dynamic_registration: Some(true), link_support: Some(true) }), type_definition: Some(GotoCapability { dynamic_registration: None, link_support: Some(true) }), implementation: Some(GotoCapability { dynamic_registration: None, link_support: Some(true) }), code_action: Some(CodeActionClientCapabilities { dynamic_registration: Some(true), code_action_literal_support: Some(CodeActionLiteralSupport { code_action_kind: CodeActionKindLiteralSupport { value_set: ["", "quickfix", "refactor", "refactor.extract", "refactor.inline", "refactor.rewrite", "source", "source.organizeImports"] } }), is_preferred_support: Some(true), disabled_support: None, data_support: Some(true), resolve_support: Some(CodeActionCapabilityResolveSupport { properties: ["edit"] }), honors_change_annotations: None }), code_lens: Some(DynamicRegistrationClientCapabilities { dynamic_registration: Some(false) }), document_link: None, color_provider: None, rename: Some(RenameClientCapabilities { dynamic_registration: Some(true), prepare_support: Some(true), prepare_support_default_behavior: None, honors_change_annotations: None }), publish_diagnostics: Some(PublishDiagnosticsClientCapabilities { related_information: Some(true), tag_support: Some(TagSupport { value_set: [Unnecessary, Deprecated] }), version_support: None, code_description_support: None, data_support: Some(true) }), folding_range: None, selection_range: None, linked_editing_range: None, call_hierarchy: Some(DynamicRegistrationClientCapabilities { dynamic_registration: Some(false) }), semantic_tokens: Some(SemanticTokensClientCapabilities { dynamic_registration: Some(false), requests: SemanticTokensClientCapabilitiesRequests { range: Some(false), full: Some(Delta { delta: Some(true) }) }, token_types: [SemanticTokenType("namespace"), SemanticTokenType("type"), SemanticTokenType("class"), SemanticTokenType("enum"), SemanticTokenType("interface"), SemanticTokenType("struct"), SemanticTokenType("typeParameter"), SemanticTokenType("parameter"), SemanticTokenType("variable"), SemanticTokenType("property"), SemanticTokenType("enumMember"), SemanticTokenType("event"), SemanticTokenType("function"), SemanticTokenType("method"), SemanticTokenType("macro"), SemanticTokenType("keyword"), SemanticTokenType("modifier"), SemanticTokenType("comment"), SemanticTokenType("string"), SemanticTokenType("number"), SemanticTokenType("regexp"), SemanticTokenType("operator"), SemanticTokenType("decorator")], token_modifiers: [SemanticTokenModifier("declaration"), SemanticTokenModifier("definition"), SemanticTokenModifier("readonly"), SemanticTokenModifier("static"), SemanticTokenModifier("deprecated"), SemanticTokenModifier("abstract"), SemanticTokenModifier("async"), SemanticTokenModifier("modification"), SemanticTokenModifier("documentation"), SemanticTokenModifier("defaultLibrary")], formats: [TokenFormat("relative")], overlapping_token_support: Some(true), multiline_token_support: Some(false), server_cancel_support: Some(false), augments_syntax_tokens: Some(true) }), moniker: None, type_hierarchy: None, inline_value: None, inlay_hint: Some(InlayHintClientCapabilities { dynamic_registration: Some(true), resolve_support: Some(InlayHintResolveClientCapabilities { properties: ["textEdits", "tooltip", "location", "command"] }) }), diagnostic: Some(DiagnosticClientCapabilities { dynamic_registration: Some(false), related_document_support: None }) }), window: Some(WindowClientCapabilities { work_done_progress: Some(true), show_message: Some(ShowMessageRequestClientCapabilities { message_action_item: Some(MessageActionItemCapabilities { additional_properties_support: Some(true) }) }), show_document: Some(ShowDocumentClientCapabilities { support: true }) }), general: Some(GeneralClientCapabilities { regular_expressions: None, markdown: None, stale_request_support: None, position_encodings: Some([PositionEncodingKind("utf-16")]) }), experimental: None }, trace: Some(Off), workspace_folders: Some([WorkspaceFolder { uri: Url { scheme: "file", cannot_be_a_base: false, username: "", password: None, host: None, port: None, path: "/home/lillis/projects/grammars/tree-sitter-c", query: None, fragment: None }, name: "/home/lillis/projects/grammars/tree-sitter-c" }]), client_info: Some(ClientInfo { name: "Neovim", version: Some("0.11.0-dev+g72a1df6065") }), locale: None }    \n'
[ERROR][2024-11-17 23:44:15] .../vim/lsp/rpc.lua:764	"rpc"	"/home/lillis/projects/ts_query_ls/target/debug/ts_query_ls"	"stderr"	'2024-11-18T04:44:15.491524Z  INFO ts_query_ls: ts_query_ls did_ops: DidOpenTextDocumentParams { text_document: TextDocumentItem { uri: Url { scheme: "file", cannot_be_a_base: false, username: "", password: None, host: None, port: None, path: "/home/lillis/projects/grammars/tree-sitter-c/queries/highlights.scm", query: None, fragment: None }, language_id: "query", version: 0, text: "(identifier) @variable\\n\\n((identifier) @constant\\n (#match? @constant \\"^[A-Z][A-Z\\\\\\\\d_]*$\\"))\\n\\n\\"break\\" @keyword\\n\\"case\\" @keyword\\n\\"const\\" @keyword\\n\\"continue\\" @keyword\\n\\"default\\" @keyword\\n\\"do\\" @keyword\\n\\"else\\" @keyword\\n\\"enum\\" @keyword\\n\\"extern\\" @keyword\\n\\"for\\" @keyword\\n\\"if\\" @keyword\\n\\"inline\\" @keyword\\n\\"return\\" @keyword\\n\\"sizeof\\" @keyword\\n\\"static\\" @keyword\\n\\"struct\\" @keyword\\n\\"switch\\" @keyword\\n\\"typedef\\" @keyword\\n\\"union\\" @keyword\\n\\"volatile\\" @keyword\\n\\"while\\" @keyword\\n\\n\\"#define\\" @keyword\\n\\"#elif\\" @keyword\\n\\"#else\\" @keyword\\n\\"#endif\\" @keyword\\n\\"#if\\" @keyword\\n\\"#ifdef\\" @keyword\\n\\"#ifndef\\" @keyword\\n\\"#include\\" @keyword\\n(preproc_directive) @keyword\\n\\n\\"--\\" @operator\\n\\"-\\" @operator\\n\\"-=\\" @operator\\n\\"->\\" @operator\\n\\"=\\" @operator\\n\\"!=\\" @operator\\n\\"*\\" @operator\\n\\"&\\" @operator\\n\\"&&\\" @operator\\n\\"+\\" @operator\\n\\"++\\" @operator\\n\\"+=\\" @operator\\n\\"<\\" @operator\\n\\"==\\" @operator\\n\\">\\" @operator\\n\\"||\\" @operator\\n\\n\\".\\" @delimiter\\n\\";\\" @delimiter\\n\\n(string_literal) @string\\n(system_lib_string) @string\\n\\n(null) @constant\\n(number_literal) @number\\n(char_literal) @number\\n\\n(field_identifier) @property\\n(statement_identifier) @label\\n(type_identifier) @type\\n(primitive_type) @type\\n(sized_type_specifier) @type\\n\\n(call_expression\\n  function: (identifier) @function)\\n(call_expression\\n  function: (field_expression\\n    field: (field_identifier) @function))\\n(function_declarator\\n  declarator: (identifier) @function)\\n(preproc_function_def\\n  name: (identifier) @function.special)\\n\\n(comment) @comment\\n" } }    \n'
```