### PR TITLE
feat: implement goto definition for captures

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ vim.api.nvim_create_autocmd('FileType', {
 - [x] Completions for node names
 - [x] Fix utility functions, making them robust when it comes to UTF-16 code
       points
-- [ ] Go to definition for captures
+- [x] Go to definition for captures
 - [ ] Recognition/completion of supertypes (requires `tree-sitter 0.25`)
 - [ ] Completions and diagnostics for a supertype's subtypes
   - Requires <https://github.com/tree-sitter/tree-sitter/pull/3938>

--- a/src/main.rs
+++ b/src/main.rs
@@ -398,23 +398,10 @@ impl LanguageServer for Backend {
             &provider,
             &rope,
         )
-        .filter(|node| {
-            if let Some(p) = node.parent() {
-                p.kind() != "parameters"
-            } else {
-                true
-            }
-        })
+        .filter(|node| node.parent().is_none_or(|p| p.kind() != "parameters"))
         .map(|node| ts_node_to_lsp_location(uri, &node, &rope))
         .collect::<Vec<Location>>();
 
-        if defs.is_empty() {
-            let range = Range::new(cur_pos, cur_pos);
-            return Ok(Some(GotoDefinitionResponse::Scalar(Location {
-                uri: uri.clone(),
-                range,
-            })));
-        }
         Ok(Some(GotoDefinitionResponse::Array(defs)))
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -364,14 +364,65 @@ impl LanguageServer for Backend {
         params: GotoDefinitionParams,
     ) -> Result<Option<GotoDefinitionResponse>> {
         info!("ts_query_ls goto_definition: {params:?}");
-        let uri = params.text_document_position_params.text_document.uri;
-        let pos = Position {
-            line: params.text_document_position_params.position.line,
-            character: 0,
+        let uri = &params.text_document_position_params.text_document.uri;
+        let Some(tree) = self.ast_map.get(uri) else {
+            warn!("No AST built for URI: {uri:?}");
+            return Ok(None);
         };
-        let range = Range::new(pos, pos);
-        Ok(Some(GotoDefinitionResponse::Scalar(Location {
+        let Some(rope) = self.document_map.get(uri) else {
+            warn!("No document built for URI: {uri:?}");
+            return Ok(None);
+        };
+        let cur_pos = params.text_document_position_params.position;
+        let Some(current_node) =
+            get_current_capture_node(tree.root_node(), lsp_position_to_ts_point(cur_pos, &rope))
+        else {
+            return Ok(None);
+        };
+
+        let query = Query::new(&QUERY_LANGUAGE, "(capture) @cap").unwrap();
+        let mut cursor = QueryCursor::new();
+        let provider = TextProviderRope(&rope);
+
+        let mut parser = Parser::new();
+        parser
+            .set_language(&QUERY_LANGUAGE)
+            .expect("Error setting language for Query parser");
+
+        let Some(def) = get_references(
             uri,
+            &tree.root_node(),
+            &current_node,
+            &query,
+            &mut cursor,
+            &provider,
+            &rope,
+        )
+        .min_by(|c1, c2| {
+            if c1 == c2 {
+                return std::cmp::Ordering::Equal;
+            }
+            let first_start_line = c1.range.start.line;
+            let elem_start_line = c2.range.start.line;
+            if (elem_start_line < first_start_line)
+                || (elem_start_line == first_start_line
+                    && c2.range.start.character < c1.range.start.character)
+            {
+                std::cmp::Ordering::Greater
+            } else {
+                std::cmp::Ordering::Less
+            }
+        }) else {
+            let range = Range::new(cur_pos, cur_pos);
+            return Ok(Some(GotoDefinitionResponse::Scalar(Location {
+                uri: uri.clone(),
+                range,
+            })));
+        };
+
+        let range = Range::new(def.range.start, def.range.end);
+        Ok(Some(GotoDefinitionResponse::Scalar(Location {
+            uri: uri.clone(),
             range,
         })))
     }


### PR DESCRIPTION
Implements goto definition for captures. The approach I took was just:

1. Collect all references for the capture in question
2. Go to the earliest occurring instance

This rests on the assumption that captures are always defined before they're used, which I *think* is true but don't know for certain. This approach could potentially be slow for large numbers of captures as it requires iterating over every single reference to the capture. However in practice this shouldn't be an issue, as usually a capture is referenced only once or twice within a query definition.

Quick demo gif:

![goto_def](https://github.com/user-attachments/assets/c6806698-d9eb-4110-a361-1435c28bd328)

(Please excuse the flickering, it only shows up in the recording and I have no idea what's causing it :upside_down_face:)