### PR TITLE
misc. cleanup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,9 @@ name = "ts_query_ls"
 version = "1.2.4"
 authors = ["Riley Bruins <ribru17@gmail.com>"]
 edition = "2021"
+description = "An LSP implementation for Tree-sitter's query files"
+license = "MIT"
+repository = "https://github.com/ribru17/ts_query_ls"
 
 [dependencies]
 dashmap = "6.1.0"


### PR DESCRIPTION
The first commit just fixes some of clippy's more pedantic lints. I wanted to note that while the explicit imports are arguably uglier than the wildcard `*` and obviously more verbose, the wildcard imports have bitten me before due to similarly named types between various lsp-related crates. 

The second just swaps "AST" for "CST" to match the verbage used in tree-sitter's [docs](https://tree-sitter.github.io/tree-sitter/). (This is such an ackshually change I kinda feel bad about it, but it may help prevent some future confusion. Feel free to disregard :laughing:)

Next todo...tests! :)