### PR TITLE
feat: add tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,14 +43,13 @@ jobs:
           components: rustfmt
       - run: cargo fmt --check
 
-  # TODO: Run this once tests are added
-  # test:
-  #   name: Test
-  #   runs-on: ubuntu-latest
-  #   timeout-minutes: 10
-  #   needs: build
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - uses: dtolnay/rust-toolchain@1.82.0
-  #       id: toolchain
-  #     - run: cargo test
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: build
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@1.82.0
+        id: toolchain
+      - run: cargo test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1220,6 +1220,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
 name = "synstructure"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1335,6 +1341,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2873938d487c3cfb9aed7546dc9f2711d867c9f90c46b889989a2cb84eba6b4f"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "tower-layer"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1358,7 +1378,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-util",
- "tower",
+ "tower 0.4.13",
  "tower-lsp-macros",
  "tracing",
 ]
@@ -1483,6 +1503,7 @@ dependencies = [
  "serde_json",
  "streaming-iterator",
  "tokio",
+ "tower 0.5.1",
  "tower-lsp",
  "tracing-subscriber",
  "tree-sitter",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -358,6 +358,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -460,6 +466,7 @@ checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
 dependencies = [
  "futures-channel",
  "futures-core",
+ "futures-executor",
  "futures-io",
  "futures-sink",
  "futures-task",
@@ -481,6 +488,17 @@ name = "futures-core"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
 
 [[package]]
 name = "futures-io"
@@ -510,6 +528,12 @@ name = "futures-task"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+
+[[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
 
 [[package]]
 name = "futures-util"
@@ -545,6 +569,12 @@ name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+
+[[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "hashbrown"
@@ -972,6 +1002,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "pretty_assertions"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
+dependencies = [
+ "diff",
+ "yansi",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b"
+dependencies = [
+ "toml_edit",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1050,6 +1099,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
+name = "relative-path"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
+
+[[package]]
 name = "ropey"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1057,6 +1112,36 @@ checksum = "93411e420bcd1a75ddd1dc3caf18c23155eda2c090631a85af21ba19e97093b5"
 dependencies = [
  "smallvec",
  "str_indices",
+]
+
+[[package]]
+name = "rstest"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a2c585be59b6b5dd66a9d2084aa1d8bd52fbdb806eafdeffb52791147862035"
+dependencies = [
+ "futures",
+ "futures-timer",
+ "rstest_macros",
+ "rustc_version",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "825ea780781b15345a146be27eaefb05085e337e869bff01b4306a4fd4a9ad5a"
+dependencies = [
+ "cfg-if",
+ "glob",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "relative-path",
+ "rustc_version",
+ "syn",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -1070,6 +1155,15 @@ name = "rustc-hash"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "rustix"
@@ -1327,6 +1421,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+
+[[package]]
+name = "toml_edit"
+version = "0.22.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
 name = "tower"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1497,8 +1608,10 @@ dependencies = [
  "lazy_static",
  "libloading",
  "log",
+ "pretty_assertions",
  "regex",
  "ropey",
+ "rstest",
  "serde",
  "serde_json",
  "streaming-iterator",
@@ -1909,6 +2022,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
+name = "winnow"
+version = "0.6.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "wit-parser"
 version = "0.217.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1937,6 +2059,12 @@ name = "writeable"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,3 +27,6 @@ tree-sitter-query = { git = "https://github.com/tree-sitter-grammars/tree-sitter
 
 [build-dependencies]
 cc = "1.1.30"
+
+[dev-dependencies]
+tower = { version = "0.5.1", features = ["util"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,4 +29,6 @@ tree-sitter-query = { git = "https://github.com/tree-sitter-grammars/tree-sitter
 cc = "1.1.30"
 
 [dev-dependencies]
+pretty_assertions = "1.4.1"
+rstest = "0.23.0"
 tower = { version = "0.5.1", features = ["util"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -316,6 +316,7 @@ struct Options {
     language_retrieval_patterns: Option<Vec<String>>,
 }
 
+mod test;
 mod util;
 
 #[tower_lsp::async_trait]

--- a/src/main.rs
+++ b/src/main.rs
@@ -309,7 +309,7 @@ struct Backend {
     options: Arc<RwLock<Options>>,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
 struct Options {
     parser_install_directories: Option<Vec<String>>,
     parser_aliases: Option<BTreeMap<String, String>>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,6 +37,21 @@ use util::{
 };
 
 lazy_static! {
+    static ref SERVER_CAPABILITIES: ServerCapabilities = ServerCapabilities {
+        text_document_sync: Some(TextDocumentSyncCapability::Kind(
+            TextDocumentSyncKind::INCREMENTAL,
+        )),
+        references_provider: Some(OneOf::Left(true)),
+        rename_provider: Some(OneOf::Left(true)),
+        definition_provider: Some(OneOf::Left(true)),
+        document_formatting_provider: Some(OneOf::Left(true)),
+        completion_provider: Some(CompletionOptions {
+            trigger_characters: Some(["@", "\"", "\\", "("].map(ToOwned::to_owned).into()),
+            ..CompletionOptions::default()
+        }),
+        document_highlight_provider: Some(OneOf::Left(true)),
+        ..Default::default()
+    };
     static ref ENGINE: Engine = Engine::default();
     static ref QUERY_LANGUAGE: Language = tree_sitter_query::LANGUAGE.into();
     static ref FORMAT_QUERY: Query = Query::new(
@@ -331,21 +346,7 @@ impl LanguageServer for Backend {
         }
 
         Ok(InitializeResult {
-            capabilities: ServerCapabilities {
-                text_document_sync: Some(TextDocumentSyncCapability::Kind(
-                    TextDocumentSyncKind::INCREMENTAL,
-                )),
-                references_provider: Some(OneOf::Left(true)),
-                rename_provider: Some(OneOf::Left(true)),
-                definition_provider: Some(OneOf::Left(true)),
-                document_formatting_provider: Some(OneOf::Left(true)),
-                completion_provider: Some(CompletionOptions {
-                    trigger_characters: Some(["@", "\"", "\\", "("].map(ToOwned::to_owned).into()),
-                    ..CompletionOptions::default()
-                }),
-                document_highlight_provider: Some(OneOf::Left(true)),
-                ..Default::default()
-            },
+            capabilities: SERVER_CAPABILITIES.clone(),
             ..Default::default()
         })
     }

--- a/src/test.rs
+++ b/src/test.rs
@@ -9,18 +9,16 @@ mod tests {
     use std::sync::RwLock;
     use tower_lsp::{
         lsp_types::{
-            ClientCapabilities, CompletionOptions, DidChangeConfigurationParams,
-            DidChangeTextDocumentParams, DidOpenTextDocumentParams, InitializeParams,
-            InitializeResult, OneOf, PartialResultParams, Position, Range, ReferenceContext,
-            ReferenceParams, ServerCapabilities, TextDocumentContentChangeEvent,
-            TextDocumentIdentifier, TextDocumentItem, TextDocumentPositionParams,
-            TextDocumentSyncCapability, TextDocumentSyncKind, Url, VersionedTextDocumentIdentifier,
-            WorkDoneProgressParams,
+            ClientCapabilities, DidChangeConfigurationParams, DidChangeTextDocumentParams,
+            DidOpenTextDocumentParams, InitializeParams, InitializeResult, PartialResultParams,
+            Position, Range, ReferenceContext, ReferenceParams, TextDocumentContentChangeEvent,
+            TextDocumentIdentifier, TextDocumentItem, TextDocumentPositionParams, Url,
+            VersionedTextDocumentIdentifier, WorkDoneProgressParams,
         },
         LanguageServer, LspService,
     };
 
-    use crate::{Backend, Options, QUERY_LANGUAGE};
+    use crate::{Backend, Options, QUERY_LANGUAGE, SERVER_CAPABILITIES};
 
     lazy_static! {
         static ref TEST_URI: Url = Url::parse("file:///tmp/test.scm").unwrap();
@@ -330,23 +328,7 @@ mod tests {
         assert_eq!(
             resp,
             InitializeResult {
-                capabilities: ServerCapabilities {
-                    text_document_sync: Some(TextDocumentSyncCapability::Kind(
-                        TextDocumentSyncKind::INCREMENTAL,
-                    )),
-                    references_provider: Some(OneOf::Left(true)),
-                    rename_provider: Some(OneOf::Left(true)),
-                    definition_provider: Some(OneOf::Left(true)),
-                    document_formatting_provider: Some(OneOf::Left(true)),
-                    completion_provider: Some(CompletionOptions {
-                        trigger_characters: Some(
-                            ["@", "\"", "\\", "("].map(ToOwned::to_owned).into()
-                        ),
-                        ..CompletionOptions::default()
-                    }),
-                    document_highlight_provider: Some(OneOf::Left(true)),
-                    ..Default::default()
-                },
+                capabilities: SERVER_CAPABILITIES.clone(),
                 ..Default::default()
             }
         );

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,0 +1,241 @@
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use ropey::Rope;
+    use tower_lsp::lsp_types::{Position, Range, Url};
+    use tree_sitter::{Query, QueryCursor};
+
+    use crate::{
+        util::{
+            get_current_capture_node, get_references, lsp_position_to_ts_point,
+            ts_node_to_lsp_location, TextProviderRope,
+        },
+        QUERY_LANGUAGE,
+    };
+
+    fn test_capture_references(input: &str) {
+        let handle_cursor_marker =
+            |input: &mut String,
+             line_num: usize,
+             idx: usize,
+             cursor_position: &mut Option<Position>| {
+                assert!(
+                    cursor_position.is_none(),
+                    "Only one cursor is supported inside text inputs"
+                );
+                *cursor_position = Some(Position {
+                    line: line_num as u32,
+                    character: idx as u32,
+                });
+                *input = input.replacen("<CURSOR>", "", 1);
+            };
+        let handle_ref_marker =
+            |input: &mut String, line_num: usize, idx: usize, ref_positions: &mut Vec<Range>| {
+                let line = input.lines().nth(line_num).unwrap();
+                assert!(
+                    line.chars().nth(idx + "<REF>".len()) == Some('@'),
+                    "capture must immediately follow <REF> marker"
+                );
+                // We temporarily remove any cursor markers to cover the case in
+                // which they share a capture with the current ref. This way, we get
+                // an accurate end index for the word
+                let counting_line = line.replace("<CURSOR>", "");
+                let end = idx
+                    + counting_line
+                        .chars()
+                        .enumerate()
+                        .skip(idx + "<REF>".len() + 1) // skip past "<REF>@"
+                        .take_while(|(_, c)| {
+                            // NOTE: What is the actual legal character set?
+                            c.is_alphanumeric() || c.eq(&'_') || c.eq(&'.')
+                        })
+                        .count()
+                    + 1; // account for skipping past initial '@'
+
+                ref_positions.push(Range::new(
+                    Position {
+                        line: line_num as u32,
+                        character: idx as u32,
+                    },
+                    Position {
+                        line: line_num as u32,
+                        character: end as u32,
+                    },
+                ));
+                *input = input.replacen("<REF>", "", 1);
+            };
+
+        let mut cursor_position: Option<Position> = None;
+        let mut expected_refs: Vec<Range> = Vec::new();
+        let mut cleaned_input = input.to_string();
+        // Go through line by line, just pick out the earlier marker instance
+        'finder_loop: loop {
+            for (line_num, line) in cleaned_input.lines().enumerate() {
+                let cursor_idx = line.match_indices("<CURSOR>").next();
+                let ref_idx = line.match_indices("<REF>").next();
+                match (cursor_idx, ref_idx) {
+                    (Some((c_idx, _)), None) => {
+                        handle_cursor_marker(
+                            &mut cleaned_input,
+                            line_num,
+                            c_idx,
+                            &mut cursor_position,
+                        );
+                        continue 'finder_loop;
+                    }
+                    (None, Some((r_idx, _))) => {
+                        handle_ref_marker(&mut cleaned_input, line_num, r_idx, &mut expected_refs);
+                        continue 'finder_loop;
+                    }
+                    (Some((c_idx, _)), Some((r_idx, _))) => {
+                        if c_idx < r_idx {
+                            handle_cursor_marker(
+                                &mut cleaned_input,
+                                line_num,
+                                c_idx,
+                                &mut cursor_position,
+                            );
+                        } else {
+                            handle_ref_marker(
+                                &mut cleaned_input,
+                                line_num,
+                                r_idx,
+                                &mut expected_refs,
+                            );
+                        }
+                        continue 'finder_loop;
+                    }
+                    (None, None) => {}
+                }
+            }
+            break 'finder_loop;
+        }
+
+        let cursor_position =
+            cursor_position.expect("textDocument/references test must contain one <CURSOR> marker");
+
+        let uri = Url::from_str("file://test.scm").unwrap();
+        let mut parser = tree_sitter::Parser::new();
+        parser
+            .set_language(&QUERY_LANGUAGE)
+            .expect("Failed to set language");
+        let tree = parser
+            .parse(&cleaned_input, None)
+            .expect("Failed to parse input");
+        let rope = Rope::from_str(&cleaned_input);
+        let provider = TextProviderRope(&rope);
+        let query = Query::new(&QUERY_LANGUAGE, "(capture) @cap").unwrap();
+        let mut cursor = QueryCursor::new();
+        let cur_pos = lsp_position_to_ts_point(cursor_position, &rope);
+        let Some(current_node) = get_current_capture_node(tree.root_node(), cur_pos) else {
+            panic!("No capture node found under cursor");
+        };
+
+        let found_refs = get_references(
+            &tree.root_node(),
+            &current_node,
+            &query,
+            &mut cursor,
+            &provider,
+            &rope,
+        )
+        .map(|node| ts_node_to_lsp_location(&uri, &node, &rope).range)
+        .collect::<Vec<Range>>();
+
+        let mut panic_msg = String::new();
+        for reference in found_refs {
+            let Some(idx) = expected_refs
+                .iter()
+                .enumerate()
+                .find(|(_, &r)| r == reference)
+                .map(|(i, _)| i)
+            else {
+                let line = cleaned_input
+                    .lines()
+                    .nth(reference.start.line as usize)
+                    .unwrap();
+                panic_msg += &format!(
+                    "Found unexpected reference at position ({}, {}), ({}, {}):\n{line}\n{}{}\n",
+                    reference.start.line,
+                    reference.start.character,
+                    reference.end.line,
+                    reference.end.character,
+                    " ".repeat(reference.start.character as usize),
+                    "^".repeat((reference.end.character - reference.start.character) as usize),
+                );
+                continue;
+            };
+            expected_refs.remove(idx);
+        }
+
+        for reference in expected_refs {
+            let line = cleaned_input
+                .lines()
+                .nth(reference.start.line as usize)
+                .unwrap();
+            panic_msg += &format!(
+                "Failed to find expected reference at position ({}, {}), ({}, {}):\n{line}\n{}{}\n",
+                reference.start.line,
+                reference.start.character,
+                reference.end.line,
+                reference.end.character,
+                " ".repeat(reference.start.character as usize),
+                "^".repeat((reference.end.character - reference.start.character) as usize),
+            );
+        }
+
+        assert!(panic_msg.is_empty(), "{panic_msg}");
+    }
+
+    /*
+     *  tree-sitter-c queries
+     */
+    #[test]
+    fn it_gives_references_for_captures_0() {
+        let src = "(identifier) <REF>@variab<CURSOR>le";
+        test_capture_references(src);
+    }
+    #[test]
+    fn it_gives_references_for_captures_1() {
+        let src = r#"((identifier) <REF>@constant
+    (#match? <REF>@c<CURSOR>onstant "^[A-Z][A-Z\\d_]*$"))"#;
+        test_capture_references(src);
+    }
+    #[test]
+    fn it_gives_references_for_captures_2() {
+        let src =
+            r"(type_definition declarator: (type_identifier) @name) <REF>@defin<CURSOR>ition.type";
+        test_capture_references(src);
+    }
+    #[test]
+    fn it_gives_references_for_captures_3() {
+        let src = r"(call_expression
+    function: (identifier) <REF>@<CURSOR>function)";
+        test_capture_references(src);
+    }
+
+    /*
+     * Other
+     */
+    #[test]
+    fn it_gives_references_for_captures_4() {
+        let src = r#"; html(`...`), html`...`, sql(`...`), etc.
+(call_expression
+  function: (identifier) @injection.language
+  arguments: [
+    (arguments
+      (template_string) <REF>@injection.content)
+    (template_string) <REF>@injection<CURSOR>.content
+  ]
+  (#lua-match? @injection.language "^[a-zA-Z][a-zA-Z0-9]*$")
+  (#offset! <REF>@injection.content 0 1 0 -1)
+  (#set! injection.include-children)
+  ; Languages excluded from auto-injection due to special rules
+  ; - svg uses the html parser
+  ; - css uses the styled parser
+  (#not-any-of? @injection.language "svg" "css"))"#;
+        test_capture_references(src);
+    }
+    // TODO: Pull out more tests from other tree-sitter repos
+}

--- a/src/test.rs
+++ b/src/test.rs
@@ -731,17 +731,14 @@ function: (identifier) @function)",
         test_server_completions(source, &expected_comps).await;
     }
 
-    //    TODO: Requires server's `symbols_vec_map` to be populated
-    //    #[tokio::test(flavor = "current_thread")]
-    //    async fn it_provides_symbol_completions() {
-    //        let source = r#"((ident<CURSOR>) @constant
-    // (#match? @constant "^[A-Z][A-Z\\d_]*$"))"#;
-    //        let expected_comps = vec![expected_named_symbol_completion("identifier")];
-    //        test_server_completions(source, &expected_comps).await;
-    //    }
+    #[tokio::test(flavor = "current_thread")]
+    async fn it_provides_symbol_completions() {
+        let source = r#"((ident<CURSOR>) @constant
+    (#match? @constant "^[A-Z][A-Z\\d_]*$"))"#;
+        let expected_comps = vec![expected_named_symbol_completion("identifier")];
+        test_server_completions(source, &expected_comps).await;
+    }
 
-    // TODO: Probably want to replicate this test to make sure other completions
-    // aren't offered inside of comments, not just captures
     #[tokio::test(flavor = "current_thread")]
     async fn it_doesnt_provide_completions_inside_comments() {
         let source = r"((identifier) @constant
@@ -762,10 +759,10 @@ function: (identifier) @function)",
     //     (text, Some(CompletionItemKind::FIELD))
     // }
     //
-    // fn expected_named_symbol_completion(text: &str) -> (&str, Option<CompletionItemKind>) {
-    //     (text, Some(CompletionItemKind::CLASS))
-    // }
-    //
+    fn expected_named_symbol_completion(text: &str) -> (&str, Option<CompletionItemKind>) {
+        (text, Some(CompletionItemKind::CLASS))
+    }
+
     // fn expected_unnamed_symbol_completion(text: &str) -> (&str, Option<CompletionItemKind>) {
     //     (text, Some(CompletionItemKind::CONSTANT))
     // }
@@ -792,10 +789,17 @@ function: (identifier) @function)",
             cursor_position.expect("Expected one <CURSOR> marker in test input, found none");
         let cleaned_input = source.replace("<CURSOR>", "");
 
-        let mut service =
-            initialize_server(&[(TEST_URI.clone(), &cleaned_input, Vec::new(), Vec::new())])
-                .await
-                .0;
+        let mut service = initialize_server(&[(
+            TEST_URI.clone(),
+            &cleaned_input,
+            vec![SymbolInfo {
+                named: true,
+                label: String::from("identifier"),
+            }],
+            Vec::new(),
+        )])
+        .await
+        .0;
         let data = service
             .ready()
             .await

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,20 +1,86 @@
 #[cfg(test)]
 mod tests {
-    use std::str::FromStr;
+    use lazy_static::lazy_static;
+    use std::sync::Arc;
 
-    use ropey::Rope;
-    use tower_lsp::lsp_types::{Position, Range, Url};
-    use tree_sitter::{Query, QueryCursor};
-
-    use crate::{
-        util::{
-            get_current_capture_node, get_references, lsp_position_to_ts_point,
-            ts_node_to_lsp_location, TextProviderRope,
+    use dashmap::DashMap;
+    use std::sync::RwLock;
+    use tower_lsp::{
+        lsp_types::{
+            ClientCapabilities, DidOpenTextDocumentParams, InitializeParams, PartialResultParams,
+            Position, Range, ReferenceContext, ReferenceParams, TextDocumentIdentifier,
+            TextDocumentItem, TextDocumentPositionParams, Url, WorkDoneProgressParams,
         },
-        QUERY_LANGUAGE,
+        LanguageServer, LspService,
     };
 
-    fn test_capture_references(input: &str) {
+    use tokio::sync::Mutex;
+
+    use crate::{Backend, Options};
+
+    lazy_static! {
+        static ref TEST_URI: Url = Url::parse("file:///tmp/test.scm").unwrap();
+    }
+
+    /// Initializes a mock instance of `ts_query_ls`
+    /// The result is wrapped in a `tokio::sync::Mutex` for safe sharing
+    /// between threads
+    async fn initialize_test_server() -> Mutex<LspService<Backend>> {
+        let options = Arc::new(RwLock::new(Options {
+            parser_install_directories: None,
+            parser_aliases: None,
+            language_retrieval_patterns: None,
+        }));
+        let (service, _socket) = LspService::build(|client| Backend {
+            client,
+            document_map: DashMap::new(),
+            cst_map: DashMap::new(),
+            symbols_set_map: DashMap::new(),
+            symbols_vec_map: DashMap::new(),
+            fields_set_map: DashMap::new(),
+            fields_vec_map: DashMap::new(),
+            options,
+        })
+        .finish();
+
+        _ = service
+            .inner()
+            .initialize(InitializeParams {
+                capabilities: ClientCapabilities::default(),
+                root_uri: Some(Url::parse("file:///tmp/").unwrap()),
+                ..Default::default()
+            })
+            .await
+            .expect("Failed to initialize server");
+        service.into()
+    }
+
+    /// Mocks the test server opening a text document with `contents`
+    async fn open_document(server: &mut Mutex<LspService<Backend>>, contents: &str) {
+        server
+            .get_mut()
+            .inner()
+            .did_open(DidOpenTextDocumentParams {
+                text_document: TextDocumentItem {
+                    uri: TEST_URI.clone(),
+                    language_id: String::from("query"),
+                    version: 0,
+                    text: contents.to_string(),
+                },
+            })
+            .await;
+        assert!(
+            server
+                .get_mut()
+                .inner()
+                .document_map
+                .get(&TEST_URI)
+                .is_some(),
+            "Failed to insert contents of mock document"
+        );
+    }
+
+    async fn test_capture_references(input: &str) {
         let handle_cursor_marker =
             |input: &mut String,
              line_num: usize,
@@ -115,54 +181,51 @@ mod tests {
         let cursor_position =
             cursor_position.expect("textDocument/references test must contain one <CURSOR> marker");
 
-        let uri = Url::from_str("file://test.scm").unwrap();
-        let mut parser = tree_sitter::Parser::new();
-        parser
-            .set_language(&QUERY_LANGUAGE)
-            .expect("Failed to set language");
-        let tree = parser
-            .parse(&cleaned_input, None)
-            .expect("Failed to parse input");
-        let rope = Rope::from_str(&cleaned_input);
-        let provider = TextProviderRope(&rope);
-        let query = Query::new(&QUERY_LANGUAGE, "(capture) @cap").unwrap();
-        let mut cursor = QueryCursor::new();
-        let cur_pos = lsp_position_to_ts_point(cursor_position, &rope);
-        let Some(current_node) = get_current_capture_node(tree.root_node(), cur_pos) else {
-            panic!("No capture node found under cursor");
-        };
-
-        let found_refs = get_references(
-            &tree.root_node(),
-            &current_node,
-            &query,
-            &mut cursor,
-            &provider,
-            &rope,
-        )
-        .map(|node| ts_node_to_lsp_location(&uri, &node, &rope).range)
-        .collect::<Vec<Range>>();
+        let mut server = initialize_test_server().await;
+        open_document(&mut server, &cleaned_input).await;
+        let found_refs = server
+            .get_mut()
+            .inner()
+            .references(ReferenceParams {
+                text_document_position: TextDocumentPositionParams {
+                    text_document: TextDocumentIdentifier {
+                        uri: TEST_URI.clone(),
+                    },
+                    position: cursor_position,
+                },
+                work_done_progress_params: WorkDoneProgressParams::default(),
+                partial_result_params: PartialResultParams::default(),
+                context: ReferenceContext {
+                    include_declaration: true,
+                },
+            })
+            .await
+            .map_err(|e| format!("textDocument/references call returned error: {e}"))
+            .unwrap()
+            .expect("textDocument/references call returned None");
 
         let mut panic_msg = String::new();
         for reference in found_refs {
             let Some(idx) = expected_refs
                 .iter()
                 .enumerate()
-                .find(|(_, &r)| r == reference)
+                .find(|(_, &r)| r == reference.range)
                 .map(|(i, _)| i)
             else {
                 let line = cleaned_input
                     .lines()
-                    .nth(reference.start.line as usize)
+                    .nth(reference.range.start.line as usize)
                     .unwrap();
                 panic_msg += &format!(
                     "Found unexpected reference at position ({}, {}), ({}, {}):\n{line}\n{}{}\n",
-                    reference.start.line,
-                    reference.start.character,
-                    reference.end.line,
-                    reference.end.character,
-                    " ".repeat(reference.start.character as usize),
-                    "^".repeat((reference.end.character - reference.start.character) as usize),
+                    reference.range.start.line,
+                    reference.range.start.character,
+                    reference.range.end.line,
+                    reference.range.end.character,
+                    " ".repeat(reference.range.start.character as usize),
+                    "^".repeat(
+                        (reference.range.end.character - reference.range.start.character) as usize
+                    ),
                 );
                 continue;
             };
@@ -191,51 +254,51 @@ mod tests {
     /*
      *  tree-sitter-c queries
      */
-    #[test]
-    fn it_gives_references_for_captures_0() {
+    #[tokio::test]
+    async fn it_gives_references_for_captures_0() {
         let src = "(identifier) <REF>@variab<CURSOR>le";
-        test_capture_references(src);
+        test_capture_references(src).await;
     }
-    #[test]
-    fn it_gives_references_for_captures_1() {
+    #[tokio::test]
+    async fn it_gives_references_for_captures_1() {
         let src = r#"((identifier) <REF>@constant
-    (#match? <REF>@c<CURSOR>onstant "^[A-Z][A-Z\\d_]*$"))"#;
-        test_capture_references(src);
+        (#match? <REF>@c<CURSOR>onstant "^[A-Z][A-Z\\d_]*$"))"#;
+        test_capture_references(src).await;
     }
-    #[test]
-    fn it_gives_references_for_captures_2() {
+    #[tokio::test]
+    async fn it_gives_references_for_captures_2() {
         let src =
             r"(type_definition declarator: (type_identifier) @name) <REF>@defin<CURSOR>ition.type";
-        test_capture_references(src);
+        test_capture_references(src).await;
     }
-    #[test]
-    fn it_gives_references_for_captures_3() {
+    #[tokio::test]
+    async fn it_gives_references_for_captures_3() {
         let src = r"(call_expression
-    function: (identifier) <REF>@<CURSOR>function)";
-        test_capture_references(src);
+        function: (identifier) <REF>@<CURSOR>function)";
+        test_capture_references(src).await;
     }
 
     /*
      * Other
      */
-    #[test]
-    fn it_gives_references_for_captures_4() {
+    #[tokio::test]
+    async fn it_gives_references_for_captures_4() {
         let src = r#"; html(`...`), html`...`, sql(`...`), etc.
-(call_expression
-  function: (identifier) @injection.language
-  arguments: [
-    (arguments
-      (template_string) <REF>@injection.content)
-    (template_string) <REF>@injection<CURSOR>.content
-  ]
-  (#lua-match? @injection.language "^[a-zA-Z][a-zA-Z0-9]*$")
-  (#offset! <REF>@injection.content 0 1 0 -1)
-  (#set! injection.include-children)
-  ; Languages excluded from auto-injection due to special rules
-  ; - svg uses the html parser
-  ; - css uses the styled parser
-  (#not-any-of? @injection.language "svg" "css"))"#;
-        test_capture_references(src);
+    (call_expression
+      function: (identifier) @injection.language
+      arguments: [
+        (arguments
+          (template_string) <REF>@injection.content)
+        (template_string) <REF>@injection<CURSOR>.content
+      ]
+      (#lua-match? @injection.language "^[a-zA-Z][a-zA-Z0-9]*$")
+      (#offset! <REF>@injection.content 0 1 0 -1)
+      (#set! injection.include-children)
+      ; Languages excluded from auto-injection due to special rules
+      ; - svg uses the html parser
+      ; - css uses the styled parser
+      (#not-any-of? @injection.language "svg" "css"))"#;
+        test_capture_references(src).await;
     }
     // TODO: Pull out more tests from other tree-sitter repos
 }

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,31 +1,37 @@
 #[cfg(test)]
 mod tests {
     use lazy_static::lazy_static;
-    use std::sync::Arc;
+    use ropey::Rope;
+    use std::{collections::BTreeMap, sync::Arc};
+    use tree_sitter::Parser;
 
     use dashmap::DashMap;
     use std::sync::RwLock;
     use tower_lsp::{
         lsp_types::{
-            ClientCapabilities, DidOpenTextDocumentParams, InitializeParams, PartialResultParams,
-            Position, Range, ReferenceContext, ReferenceParams, TextDocumentIdentifier,
-            TextDocumentItem, TextDocumentPositionParams, Url, WorkDoneProgressParams,
+            ClientCapabilities, CompletionOptions, DidChangeConfigurationParams,
+            DidChangeTextDocumentParams, DidOpenTextDocumentParams, InitializeParams,
+            InitializeResult, OneOf, PartialResultParams, Position, Range, ReferenceContext,
+            ReferenceParams, ServerCapabilities, TextDocumentContentChangeEvent,
+            TextDocumentIdentifier, TextDocumentItem, TextDocumentPositionParams,
+            TextDocumentSyncCapability, TextDocumentSyncKind, Url, VersionedTextDocumentIdentifier,
+            WorkDoneProgressParams,
         },
         LanguageServer, LspService,
     };
 
-    use tokio::sync::Mutex;
-
-    use crate::{Backend, Options};
+    use crate::{Backend, Options, QUERY_LANGUAGE};
 
     lazy_static! {
         static ref TEST_URI: Url = Url::parse("file:///tmp/test.scm").unwrap();
     }
 
-    /// Initializes a mock instance of `ts_query_ls`
-    /// The result is wrapped in a `tokio::sync::Mutex` for safe sharing
-    /// between threads
-    async fn initialize_test_server() -> Mutex<LspService<Backend>> {
+    /// Initialize a test server, populating it with fake documents denoted by (uri, text) pairs.
+    async fn initialize_server(documents: &[(Url, &str)]) -> LspService<Backend> {
+        let mut parser = Parser::new();
+        parser
+            .set_language(&QUERY_LANGUAGE)
+            .expect("Error loading Query grammar");
         let options = Arc::new(RwLock::new(Options {
             parser_install_directories: None,
             parser_aliases: None,
@@ -33,8 +39,16 @@ mod tests {
         }));
         let (service, _socket) = LspService::build(|client| Backend {
             client,
-            document_map: DashMap::new(),
-            cst_map: DashMap::new(),
+            document_map: DashMap::from_iter(
+                documents
+                    .iter()
+                    .map(|(uri, source)| (uri.clone(), Rope::from(*source))),
+            ),
+            cst_map: DashMap::from_iter(
+                documents
+                    .iter()
+                    .map(|(uri, source)| (uri.clone(), parser.parse(*source, None).unwrap())),
+            ),
             symbols_set_map: DashMap::new(),
             symbols_vec_map: DashMap::new(),
             fields_set_map: DashMap::new(),
@@ -43,41 +57,19 @@ mod tests {
         })
         .finish();
 
-        _ = service
+        service
             .inner()
             .initialize(InitializeParams {
-                capabilities: ClientCapabilities::default(),
+                capabilities: ClientCapabilities {
+                    ..Default::default()
+                },
                 root_uri: Some(Url::parse("file:///tmp/").unwrap()),
                 ..Default::default()
             })
             .await
-            .expect("Failed to initialize server");
-        service.into()
-    }
+            .unwrap();
 
-    /// Mocks the test server opening a text document with `contents`
-    async fn open_document(server: &mut Mutex<LspService<Backend>>, contents: &str) {
-        server
-            .get_mut()
-            .inner()
-            .did_open(DidOpenTextDocumentParams {
-                text_document: TextDocumentItem {
-                    uri: TEST_URI.clone(),
-                    language_id: String::from("query"),
-                    version: 0,
-                    text: contents.to_string(),
-                },
-            })
-            .await;
-        assert!(
-            server
-                .get_mut()
-                .inner()
-                .document_map
-                .get(&TEST_URI)
-                .is_some(),
-            "Failed to insert contents of mock document"
-        );
+        service
     }
 
     async fn test_capture_references(input: &str) {
@@ -181,10 +173,8 @@ mod tests {
         let cursor_position =
             cursor_position.expect("textDocument/references test must contain one <CURSOR> marker");
 
-        let mut server = initialize_test_server().await;
-        open_document(&mut server, &cleaned_input).await;
+        let server = initialize_server(&[(TEST_URI.clone(), cleaned_input.as_str())]).await;
         let found_refs = server
-            .get_mut()
             .inner()
             .references(ReferenceParams {
                 text_document_position: TextDocumentPositionParams {
@@ -202,7 +192,8 @@ mod tests {
             .await
             .map_err(|e| format!("textDocument/references call returned error: {e}"))
             .unwrap()
-            .expect("textDocument/references call returned None");
+            .unwrap_or_default(); // Prefer an empty `Vec` over `None` so the missing
+                                  // refs get printed in `panic_msg` below
 
         let mut panic_msg = String::new();
         for reference in found_refs {
@@ -301,4 +292,189 @@ mod tests {
         test_capture_references(src).await;
     }
     // TODO: Pull out more tests from other tree-sitter repos
+
+    #[tokio::test]
+    async fn test_server_initialize() {
+        // Arrange
+        let options = Arc::new(RwLock::new(Options {
+            parser_install_directories: None,
+            parser_aliases: None,
+            language_retrieval_patterns: None,
+        }));
+        let (service, _socket) = LspService::build(|client| Backend {
+            client,
+            document_map: DashMap::new(),
+            cst_map: DashMap::new(),
+            symbols_set_map: DashMap::new(),
+            symbols_vec_map: DashMap::new(),
+            fields_set_map: DashMap::new(),
+            fields_vec_map: DashMap::new(),
+            options,
+        })
+        .finish();
+
+        // Act
+        let resp = service
+            .inner()
+            .initialize(InitializeParams {
+                capabilities: ClientCapabilities {
+                    ..Default::default()
+                },
+                root_uri: Some(Url::parse("file:///tmp/").unwrap()),
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+
+        // Assert
+        assert_eq!(
+            resp,
+            InitializeResult {
+                capabilities: ServerCapabilities {
+                    text_document_sync: Some(TextDocumentSyncCapability::Kind(
+                        TextDocumentSyncKind::INCREMENTAL,
+                    )),
+                    references_provider: Some(OneOf::Left(true)),
+                    rename_provider: Some(OneOf::Left(true)),
+                    definition_provider: Some(OneOf::Left(true)),
+                    document_formatting_provider: Some(OneOf::Left(true)),
+                    completion_provider: Some(CompletionOptions {
+                        trigger_characters: Some(
+                            ["@", "\"", "\\", "("].map(ToOwned::to_owned).into()
+                        ),
+                        ..CompletionOptions::default()
+                    }),
+                    document_highlight_provider: Some(OneOf::Left(true)),
+                    ..Default::default()
+                },
+                ..Default::default()
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn test_server_did_open() {
+        // Arrange
+        let service = initialize_server(&[]).await;
+        let source = r#"
+        "[" @cap
+        "#;
+
+        // Act
+        service
+            .inner()
+            .did_open(DidOpenTextDocumentParams {
+                text_document: TextDocumentItem {
+                    uri: TEST_URI.clone(),
+                    language_id: String::from("query"),
+                    version: 0,
+                    text: String::from(source),
+                },
+            })
+            .await;
+
+        // Assert
+        let doc_rope = service.inner().document_map.get(&TEST_URI);
+        assert!(doc_rope.is_some());
+        let doc_rope = doc_rope.unwrap();
+        assert_eq!(doc_rope.to_string(), source);
+    }
+
+    #[tokio::test]
+    async fn test_server_did_change_configuration() {
+        // Arrange
+        let service = initialize_server(&[]).await;
+
+        // Act
+        service
+            .inner()
+            .did_change_configuration(DidChangeConfigurationParams {
+                settings: serde_json::from_str(
+                    r#"
+                    {
+                      "parser_aliases": {
+                        "ecma": "javascript",
+                        "jsx": "javascript",
+                        "foolang": "barlang"
+                      }
+                    }
+                    "#,
+                )
+                .unwrap(),
+            })
+            .await;
+
+        // Assert
+        let options = service.inner().options.read();
+        assert!(options.is_ok());
+        let options = options.unwrap();
+        assert_eq!(
+            *options,
+            Options {
+                parser_aliases: Some(BTreeMap::from([
+                    ("ecma".to_string(), "javascript".to_string()),
+                    ("jsx".to_string(), "javascript".to_string()),
+                    ("foolang".to_string(), "barlang".to_string())
+                ])),
+                parser_install_directories: None,
+                language_retrieval_patterns: None
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn test_server_did_change() {
+        // Arrange
+        let source = r#"(node_name) @hello
+";" @semicolon"#;
+        let service = initialize_server(&[(TEST_URI.clone(), source)]).await;
+
+        // Act
+        let make_text_document_content_change =
+            |text: &str, start: (u32, u32), end: (u32, u32)| -> TextDocumentContentChangeEvent {
+                TextDocumentContentChangeEvent {
+                    range: Some(Range {
+                        start: Position {
+                            line: start.0,
+                            character: start.1,
+                        },
+                        end: Position {
+                            line: end.0,
+                            character: end.1,
+                        },
+                    }),
+                    range_length: None,
+                    text: String::from(text),
+                }
+            };
+        service
+            .inner()
+            .did_change(DidChangeTextDocumentParams {
+                text_document: VersionedTextDocumentIdentifier {
+                    uri: TEST_URI.clone(),
+                    version: 1,
+                },
+                content_changes: vec![
+                    make_text_document_content_change("goodbye", (0, 13), (0, 18)),
+                    make_text_document_content_change("identifier", (0, 1), (0, 10)),
+                    make_text_document_content_change("punctuation.delimiter", (1, 5), (1, 14)),
+                ],
+            })
+            .await;
+
+        // Assert
+        let doc = service.inner().document_map.get(&TEST_URI);
+        let tree = service.inner().cst_map.get(&TEST_URI);
+        let new_source = r#"(identifier) @goodbye
+";" @punctuation.delimiter"#;
+        assert!(doc.is_some());
+        let doc = doc.unwrap();
+        assert_eq!(doc.to_string(), new_source);
+        assert!(tree.is_some());
+        let tree = tree.unwrap();
+        assert_eq!(
+            tree.root_node().utf8_text(new_source.as_bytes()).unwrap(),
+            new_source
+        );
+    }
 }


### PR DESCRIPTION
(Marking as a draft for now until some questions/ decisions are settled)

Opening this as a fairly rough proof of concept for adding some unit tests to the project. In particular, this adds some coverage for the `get_references` function. The current implementation takes in a source string with a single `<CURSOR>` marker indicating where the cursor should be, and 0 or more `<REF>` markers indicating expected reference points. Said ref markers need to come directly before the capture they mark, i.e. `<REF>@foo.cap`. These markers are collected and translated into positions, the server's `get_references` function is called, and then the two sets of references are compared. I tried adding some dev helpers in the test implementation to aid in adding more tests as well. For example, what if we forgot the mark the `@function` capture as a ref in this test case:

```scm
(call_expression
    function: (identifier) @<CURSOR>function)
```

then the test runner will provide the following error message:

```sh
failures:

---- test::tests::it_gives_references_for_captures_3 stdout ----
thread 'test::tests::it_gives_references_for_captures_3' panicked at src/test.rs:188:9:
Found unexpected reference at position (1, 27), (1, 36):
    function: (identifier) @function)
                           ^^^^^^^^^
```

Similarly, if we mark a ref in the test input that shouldn't be a reference, i.e.:

```scm
(type_definition declarator: (type_identifier) <REF>@name) <REF>@defin<CURSOR>ition.type
```
then the test runner will provide the following error message:

```sh
failures:

---- test::tests::it_gives_references_for_captures_2 stdout ----
thread 'test::tests::it_gives_references_for_captures_2' panicked at src/test.rs:188:9:
Failed to find expected reference at position (0, 47), (0, 52):
(type_definition declarator: (type_identifier) @name) @definition.type
                                               ^^^^^
```

A few thoughts/questions/todos:

- What is the actual legal set of characters for capture names? (This is used inside of the `handle_ref_marker` closure)
- ~~These tests end up repeating a fair amount of logic from the server's main `references` function. I did some searching online and did find some [methods](https://github.com/ebkalderon/tower-lsp/discussions/418) for more direct testing, but I'm not sure if that's the way to go here.~~ Adopted the end-to-end test approach.
- More test cases needed/ more descriptive names. The current cases are just some queries I pulled out of tree-sitter-c, as well as [an example](https://github.com/ribru17/ts_query_ls/pull/4#issuecomment-2486920823) you gave in a previous PR review.
- Code cleanup after some more general design decisions have been settled on
- It felt a bit silly pushing the ref `Position`s into a `Vec`, but lsp_tower::lsp_types::Position` doesn't implement `Hash`, and writing a wrapper struct to get around this felt a little too verbose.