### PR TITLE
fix: proper hover display for anonymous subtypes

### DIFF
--- a/src/handlers/did_open.rs
+++ b/src/handlers/did_open.rs
@@ -95,7 +95,7 @@ pub async fn did_open(backend: &Backend, params: DidOpenTextDocumentParams) {
                         .iter()
                         .map(|s| SymbolInfo {
                             label: lang.node_kind_for_id(*s).unwrap().to_string(),
-                            named: lang.node_kind_is_named(*s),
+                            named: lang.node_kind_is_named(*s) || lang.node_kind_is_supertype(*s),
                         })
                         .collect(),
                 );

--- a/src/handlers/hover.rs
+++ b/src/handlers/hover.rs
@@ -37,11 +37,10 @@ pub async fn hover(backend: &Backend, params: HoverParams) -> Result<Option<Hove
                 .is_some_and(|p| p.kind() == "named_node" || p.kind() == "missing_node")
         {
             if let Some(subtypes) = supertypes.get(&sym).and_then(|subtypes| {
-                subtypes
-                    .iter()
-                    .fold(format!("Subtypes of `({node_text})`:\n"), |acc, subtype| {
-                        format!("{acc}\n- `({})`", subtype.label)
-                    })
+                (subtypes.iter().fold(
+                    format!("Subtypes of `({node_text})`:\n\n```query"),
+                    |acc, subtype| format!("{acc}\n{}", subtype),
+                ) + "\n```")
                     .into()
             }) {
                 return Ok(Some(Hover {
@@ -204,22 +203,28 @@ For example, this pattern would match any node inside a call:
         Position { line: 0, character: 25 } ),
     r"Subtypes of `(supertype)`:
 
-- `(test)`
-- `(test2)`")]
+```query
+(test)
+(test2)
+```")]
     #[case(SOURCE, vec!["supertype"], Position { line: 2, character: 4 }, Range::new(
         Position { line: 2, character: 1 },
         Position { line: 2, character: 10 } ),
     r"Subtypes of `(supertype)`:
 
-- `(test)`
-- `(test2)`")]
+```query
+(test)
+(test2)
+```")]
     #[case(SOURCE, vec!["supertype"], Position { line: 4, character: 10 }, Range::new(
         Position { line: 4, character: 9 },
         Position { line: 4, character: 18 } ),
     r"Subtypes of `(supertype)`:
 
-- `(test)`
-- `(test2)`")]
+```query
+(test)
+(test2)
+```")]
     #[tokio::test(flavor = "current_thread")]
     async fn hover(
         #[case] source: &str,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+use core::fmt;
 use lazy_static::lazy_static;
 use serde::{Deserialize, Serialize};
 use std::{
@@ -66,6 +67,13 @@ lazy_static! {
 struct SymbolInfo {
     label: String,
     named: bool,
+}
+
+impl fmt::Display for SymbolInfo {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let delims = if self.named { ('(', ')') } else { ('"', '"') };
+        write!(f, "{}{}{}", delims.0, self.label, delims.1)
+    }
 }
 
 struct Backend {


### PR DESCRIPTION
Anonymous node subtypes were given parentheses before, now they will be quoted. Also changed the display to be in a query code block for better highlighting