### PR TITLE
fix: prevent lots of cursor allocations during formatting

### DIFF
--- a/src/handlers/formatting.rs
+++ b/src/handlers/formatting.rs
@@ -75,7 +75,14 @@ pub async fn formatting(
 
     let mut edits = vec![String::new()];
 
-    format_iter(&rope, &tree.root_node(), &mut edits, &map, 0);
+    format_iter(
+        &rope,
+        &tree.root_node(),
+        &mut edits,
+        &map,
+        0,
+        &mut tree.walk(),
+    );
 
     Ok(Some(util::diff(
         rope.to_string().as_str(),


### PR DESCRIPTION
Now tree iteration uses one cursor formed at the root, and all children iterate using that one cursor. Previously, each child would allocate its own `TreeCursor` which was very expensive.