### PR TITLE
feat: partial support for capture name validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
         run: |
           # Generate schema
           cargo xtask schema
-          # Check for uncommitted changes (excluding schemas/workflow.ts)
+          # Check for uncommitted changes
           if [[ -n "$(git status --porcelain)" ]]; then
             echo '❌ Uncommitted changes detected after running `cargo xtask schema`:'
             git --no-pager diff

--- a/README.md
+++ b/README.md
@@ -16,7 +16,19 @@ example file:
   },
   "language_retrieval_patterns": [
     "languages/src/([^/]+)/[^/]+\\.scm$"
-  ]
+  ],
+  "allowable_captures": {
+    "highlights": [
+      {
+        "name": "variable",
+        "description": "Simple identifiers"
+      },
+      {
+        "name": "variable.parameter",
+        "description": "Parameters of a function"
+      }
+    ]
+  }
 }
 ```
 
@@ -58,6 +70,29 @@ from highest to lowest precedence. E.g., for `zed` support:
 
 - `tree-sitter-([^/]+)/queries/[^/]+\.scm$`
 - `queries/([^/]+)/[^/]+\.scm$`
+
+#### `allowable_captures`
+
+A map from query file names to allowable captures. Captures are represented as
+an object containing their name (sans `@`) and an optional description. Note
+that captures prefixed with an underscore are always permissible. Example:
+
+```json
+{
+  "allowable_captures": {
+    "highlights": [
+      {
+        "name": "variable",
+        "description": "Simple identifiers"
+      },
+      {
+        "name": "variable.parameter",
+        "description": "Parameters of a function"
+      }
+    ]
+  }
+}
+```
 
 ### Example setup (for Neovim):
 

--- a/schemas/config.json
+++ b/schemas/config.json
@@ -3,6 +3,18 @@
   "title": "Options",
   "type": "object",
   "properties": {
+    "allowable_captures": {
+      "description": "A map from query file names to allowable captures. Captures are represented as an object containing their name and an optional description. Note that captures prefixed with an underscore are always permissible.",
+      "default": {},
+      "type": "object",
+      "additionalProperties": {
+        "type": "array",
+        "items": {
+          "$ref": "#/definitions/SerializableCapture"
+        },
+        "uniqueItems": true
+      }
+    },
     "language_retrieval_patterns": {
       "description": "A list of patterns to aid the LSP in finding a language, given a file path. Patterns must have one capture group which represents the language name. Ordered from highest to lowest precedence.",
       "type": [
@@ -31,6 +43,25 @@
       ],
       "items": {
         "type": "string"
+      }
+    }
+  },
+  "definitions": {
+    "SerializableCapture": {
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "description": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "name": {
+          "type": "string"
+        }
       }
     }
   }

--- a/src/handlers/did_change_configuration.rs
+++ b/src/handlers/did_change_configuration.rs
@@ -11,7 +11,8 @@ pub async fn did_change_configuration(backend: &Backend, params: DidChangeConfig
             .read()
             .map(|uris| uris.to_vec())
             .unwrap_or_default(),
-    );
+    )
+    .await;
 }
 
 #[cfg(test)]
@@ -67,9 +68,7 @@ mod test {
             .unwrap();
 
         // Assert
-        let options = service.inner().options.read();
-        assert!(options.is_ok());
-        let options = options.unwrap();
+        let options = service.inner().options.read().await;
         assert_eq!(
             *options,
             Options {
@@ -84,7 +83,8 @@ mod test {
                 ]),
                 language_retrieval_patterns: Some(vec![String::from(
                     r"\.ts\-([^/]+)\-parser\.wasm"
-                )])
+                )]),
+                allowable_captures: Default::default()
             }
         );
     }

--- a/src/handlers/initialize.rs
+++ b/src/handlers/initialize.rs
@@ -30,7 +30,8 @@ pub async fn initialize(backend: &Backend, params: InitializeParams) -> Result<I
                 .read()
                 .map(|r| r.to_vec())
                 .unwrap_or_default(),
-        );
+        )
+        .await;
     }
 
     Ok(InitializeResult {
@@ -122,7 +123,7 @@ mod test {
             ))
         );
         let backend = service.inner();
-        let actual_options = backend.options.read().unwrap();
+        let actual_options = backend.options.read().await;
         let expected_options = serde_json::from_str::<Options>(options).unwrap();
         assert_eq!(
             actual_options.parser_aliases,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 
 use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Default, JsonSchema)]
 pub struct Options {
@@ -14,4 +14,47 @@ pub struct Options {
     /// Patterns must have one capture group which represents the language name. Ordered
     /// from highest to lowest precedence.
     pub language_retrieval_patterns: Option<Vec<String>>,
+    /// A map from query file names to allowable captures. Captures are represented as an object
+    /// containing their name and an optional description. Note that captures prefixed with an
+    /// underscore are always permissible.
+    #[serde(default, deserialize_with = "vecmap_to_setmap")]
+    pub allowable_captures: HashMap<String, BTreeSet<SerializableCapture>>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Default, JsonSchema)]
+pub struct SerializableCapture {
+    pub name: String,
+    pub description: Option<String>,
+}
+
+impl PartialEq for SerializableCapture {
+    fn eq(&self, other: &Self) -> bool {
+        self.name == other.name
+    }
+}
+impl Eq for SerializableCapture {}
+
+fn vecmap_to_setmap<'de, D>(
+    deserializer: D,
+) -> Result<HashMap<String, BTreeSet<SerializableCapture>>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let vec_map = HashMap::<String, Vec<SerializableCapture>>::deserialize(deserializer)?;
+    Ok(vec_map
+        .into_iter()
+        .map(|(k, v)| (k, v.into_iter().collect()))
+        .collect())
+}
+
+impl Ord for SerializableCapture {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.name.cmp(&other.name)
+    }
+}
+
+impl PartialOrd for SerializableCapture {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -90,7 +90,7 @@ struct Backend {
     fields_set_map: DashMap<Url, HashSet<String>>,
     fields_vec_map: DashMap<Url, Vec<String>>,
     supertype_map_map: DashMap<Url, HashMap<SymbolInfo, BTreeSet<SymbolInfo>>>,
-    options: Arc<RwLock<Options>>,
+    options: Arc<tokio::sync::RwLock<Options>>,
     workspace_uris: Arc<RwLock<Vec<Url>>>,
 }
 
@@ -337,10 +337,11 @@ async fn main() {
     let stdin = tokio::io::stdin();
     let stdout = tokio::io::stdout();
 
-    let options = Arc::new(RwLock::new(Options {
+    let options = Arc::new(tokio::sync::RwLock::new(Options {
         parser_install_directories: None,
         parser_aliases: None,
         language_retrieval_patterns: None,
+        allowable_captures: HashMap::default(),
     }));
     let (service, socket) = LspService::build(|client| Backend {
         client,

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -11,7 +11,6 @@ pub mod helpers {
     use tree_sitter::Parser;
 
     use dashmap::DashMap;
-    use std::sync::RwLock;
     use tower_lsp::{
         LspService,
         jsonrpc::{Request, Response},
@@ -79,10 +78,11 @@ pub mod helpers {
         parser
             .set_language(&QUERY_LANGUAGE)
             .expect("Error loading Query grammar");
-        let options = Arc::new(RwLock::new(Options {
+        let options = Arc::new(tokio::sync::RwLock::new(Options {
             parser_install_directories: None,
             parser_aliases: None,
             language_retrieval_patterns: None,
+            allowable_captures: HashMap::new(),
         }));
         let (mut service, _socket) = LspService::build(|client| Backend {
             client,


### PR DESCRIPTION
Currently not support by the `check` subcommand, nor autocompletions or hover.

`check` support requires https://github.com/tree-sitter/tree-sitter/pull/4384, the other TODOs can be done now