### PR TITLE
fix: expand env variables at deserialization step

### DIFF
--- a/schemas/config.json
+++ b/schemas/config.json
@@ -25,10 +25,8 @@
     },
     "parser_install_directories": {
       "description": "A list of strings representing directories to search for parsers, of the form `<lang>.(so|dll|dylib)` or `tree-sitter-<lang>.wasm`.\n\nSupports environment variable expansion of the form `${VAR}`.",
-      "type": [
-        "array",
-        "null"
-      ],
+      "default": [],
+      "type": "array",
       "items": {
         "type": "string"
       }

--- a/src/handlers/did_change_configuration.rs
+++ b/src/handlers/did_change_configuration.rs
@@ -5,7 +5,7 @@ use crate::{Backend, util::set_configuration_options};
 pub async fn did_change_configuration(backend: &Backend, params: DidChangeConfigurationParams) {
     set_configuration_options(
         backend,
-        params.settings,
+        Some(params.settings),
         backend
             .workspace_uris
             .read()
@@ -77,10 +77,10 @@ mod test {
                     ("jsx".to_string(), "javascript".to_string()),
                     ("foolang".to_string(), "barlang".to_string())
                 ])),
-                parser_install_directories: Some(vec![
+                parser_install_directories: vec![
                     String::from("/my/directory/"),
                     String::from("/tmp/tree-sitter/parsers/"),
-                ]),
+                ],
                 language_retrieval_patterns: Some(vec![String::from(
                     r"\.ts\-([^/]+)\-parser\.wasm"
                 )]),

--- a/src/handlers/initialize.rs
+++ b/src/handlers/initialize.rs
@@ -21,18 +21,16 @@ pub async fn initialize(backend: &Backend, params: InitializeParams) -> Result<I
         }
     }
 
-    if let Some(init_options) = params.initialization_options {
-        set_configuration_options(
-            backend,
-            init_options,
-            backend
-                .workspace_uris
-                .read()
-                .map(|r| r.to_vec())
-                .unwrap_or_default(),
-        )
-        .await;
-    }
+    set_configuration_options(
+        backend,
+        params.initialization_options,
+        backend
+            .workspace_uris
+            .read()
+            .map(|r| r.to_vec())
+            .unwrap_or_default(),
+    )
+    .await;
 
     Ok(InitializeResult {
         capabilities: SERVER_CAPABILITIES.clone(),
@@ -135,10 +133,10 @@ mod test {
         let actual_options = backend.options.read().await;
         let mut expected_options = serde_json::from_str::<Options>(options).unwrap();
         // Test that env vars are correctly substituted
-        expected_options.parser_install_directories = Some(vec![
+        expected_options.parser_install_directories = vec![
             String::from("/home/jdoe/my/directory/"),
             String::from("/$tmp/tree-sitter/parsers/"),
-        ]);
+        ];
         assert_eq!(
             actual_options.parser_aliases,
             expected_options.parser_aliases

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,10 @@
-use std::collections::{BTreeMap, HashMap};
+use std::{
+    collections::{BTreeMap, HashMap},
+    env,
+};
 
 use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Default, JsonSchema)]
 pub struct Options {
@@ -9,7 +12,8 @@ pub struct Options {
     /// `<lang>.(so|dll|dylib)` or `tree-sitter-<lang>.wasm`.
     ///
     /// Supports environment variable expansion of the form `${VAR}`.
-    pub parser_install_directories: Option<Vec<String>>,
+    #[serde(default, deserialize_with = "deserialize_and_expand")]
+    pub parser_install_directories: Vec<String>,
     /// A map of parser aliases.
     pub parser_aliases: Option<BTreeMap<String, String>>,
     /// A list of patterns to aid the LSP in finding a language, given a file path.
@@ -21,4 +25,45 @@ pub struct Options {
     /// prefixed with an underscore are always permissible.
     #[serde(default)]
     pub valid_captures: HashMap<String, BTreeMap<String, String>>,
+}
+
+fn expand_env_vars(input: &str) -> String {
+    let mut result = String::new();
+    let mut chars = input.chars().peekable();
+
+    while let Some(c) = chars.next() {
+        if c == '$' && chars.peek() == Some(&'{') {
+            chars.next(); // consume '{'
+            let mut var_name = String::new();
+
+            while let Some(&ch) = chars.peek() {
+                if ch == '}' {
+                    chars.next(); // consume '}'
+                    break;
+                }
+                var_name.push(ch);
+                chars.next();
+            }
+
+            // Lookup the env var
+            if let Ok(val) = env::var(&var_name) {
+                result.push_str(&val);
+            } else {
+                // Leave untouched if not found
+                result.push_str(&format!("${{{}}}", var_name));
+            }
+        } else {
+            result.push(c);
+        }
+    }
+
+    result
+}
+
+fn deserialize_and_expand<'de, D>(deserializer: D) -> Result<Vec<String>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let raw = Vec::<String>::deserialize(deserializer)?;
+    Ok(raw.into_iter().map(|s| expand_env_vars(&s)).collect())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -338,7 +338,7 @@ async fn main() {
     let stdout = tokio::io::stdout();
 
     let options = Arc::new(tokio::sync::RwLock::new(Options {
-        parser_install_directories: None,
+        parser_install_directories: Default::default(),
         parser_aliases: None,
         language_retrieval_patterns: None,
         valid_captures: Default::default(),

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -91,7 +91,7 @@ pub mod helpers {
             HashMap::new()
         };
         let options = Arc::new(tokio::sync::RwLock::new(Options {
-            parser_install_directories: None,
+            parser_install_directories: Default::default(),
             parser_aliases: None,
             language_retrieval_patterns: None,
             valid_captures,


### PR DESCRIPTION
This allows `check` to also use env var expansion. This commit also fixes an issue where the config file would not be read if the user didn't pass in any configuration options during initialization.