### PR TITLE
feat: completions for valid captures

### DIFF
--- a/src/handlers/completion.rs
+++ b/src/handlers/completion.rs
@@ -3,14 +3,15 @@ use std::collections::HashSet;
 use streaming_iterator::StreamingIterator;
 use tower_lsp::jsonrpc::Result;
 use tower_lsp::lsp_types::{
-    CompletionItem, CompletionItemKind, CompletionParams, CompletionResponse,
+    CompletionItem, CompletionItemKind, CompletionParams, CompletionResponse, CompletionTextEdit,
+    Documentation, MarkupContent, MarkupKind, Range, TextEdit,
 };
 use tracing::warn;
 use tree_sitter::QueryCursor;
 
 use crate::util::{
-    CAPTURES_QUERY, NodeUtil, TextProviderRope, ToTsPoint, lsp_position_to_byte_offset,
-    node_is_or_has_ancestor,
+    CAPTURES_QUERY, NodeUtil, TextProviderRope, ToTsPoint, get_current_capture_node,
+    lsp_position_to_byte_offset, node_is_or_has_ancestor, uri_to_basename,
 };
 use crate::{Backend, SymbolInfo};
 
@@ -83,10 +84,10 @@ pub async fn completion(
         .is_ok_and(|c| rope.char(c) == '@');
     let root = tree.root_node();
     let in_capture = cursor_after_at_sign || node_is_or_has_ancestor(root, current_node, "capture");
+    let in_predicate = node_is_or_has_ancestor(root, current_node, "predicate");
     let in_missing = node_is_or_has_ancestor(root, current_node, "missing_node");
-    if !in_capture && !node_is_or_has_ancestor(root, current_node, "predicate") {
-        let in_anon = node_is_or_has_ancestor(root, current_node, "string")
-            && !node_is_or_has_ancestor(root, current_node, "predicate");
+    if !in_capture && !in_predicate {
+        let in_anon = node_is_or_has_ancestor(root, current_node, "string") && !in_predicate;
         let top_level = current_node.kind() == "program";
         if !top_level {
             if let (Some(symbols), Some(supertypes)) = (
@@ -133,33 +134,77 @@ pub async fn completion(
     }
 
     // Capture completions
-    if !node_is_or_has_ancestor(tree.root_node(), current_node, "predicate")
-        || node_is_or_has_ancestor(tree.root_node(), current_node, "string")
-    {
+    if node_is_or_has_ancestor(tree.root_node(), current_node, "string") {
         return Ok(Some(CompletionResponse::Array(completion_items)));
     }
-    let node = match tree.root_node().child_with_descendant(current_node) {
-        None => return Ok(Some(CompletionResponse::Array(completion_items))),
-        Some(value) => value,
-    };
-    let provider = TextProviderRope(rope);
-    let mut iter = cursor.matches(query, node, &provider);
-    let mut seen = HashSet::new();
-    while let Some(match_) = iter.next() {
-        for capture in match_.captures {
-            let node_text = capture.node.text(rope);
-            let parent_params = capture
-                .node
-                .parent()
-                .is_none_or(|p| p.kind() != "parameters");
-            if parent_params && !seen.contains(&node_text) {
-                seen.insert(node_text.clone());
-                completion_items.push(CompletionItem {
-                    label: node_text.clone(),
-                    kind: Some(CompletionItemKind::VARIABLE),
-                    ..Default::default()
-                });
+    let mut text_edit = get_current_capture_node(root, point).map_or_else(
+        || {
+            Some(CompletionTextEdit::Edit(TextEdit {
+                new_text: Default::default(),
+                range: Range {
+                    start: position,
+                    end: params.text_document_position.position,
+                },
+            }))
+        },
+        |cap_node| {
+            Some(CompletionTextEdit::Edit(TextEdit {
+                new_text: Default::default(),
+                range: cap_node.lsp_range(rope),
+            }))
+        },
+    );
+    if in_predicate {
+        let pattern_node = match root.child_with_descendant(current_node) {
+            None => return Ok(Some(CompletionResponse::Array(completion_items))),
+            Some(value) => value,
+        };
+        let provider = TextProviderRope(rope);
+        let mut iter = cursor.matches(query, pattern_node, &provider);
+        let mut seen = HashSet::new();
+        let mut text_edit = if in_capture { text_edit } else { None };
+        while let Some(match_) = iter.next() {
+            for capture in match_.captures {
+                let node_text = capture.node.text(rope);
+                if let Some(CompletionTextEdit::Edit(edit)) = text_edit.as_mut() {
+                    edit.new_text = node_text.clone();
+                };
+                let parent_params = capture
+                    .node
+                    .parent()
+                    .is_none_or(|p| p.kind() != "parameters");
+                if parent_params && !seen.contains(&node_text) {
+                    seen.insert(node_text.clone());
+                    completion_items.push(CompletionItem {
+                        label: node_text.clone(),
+                        kind: Some(CompletionItemKind::VARIABLE),
+                        text_edit: text_edit.clone(),
+                        ..Default::default()
+                    });
+                }
             }
+        }
+    } else if in_capture {
+        let options = backend.options.read().await;
+        if let Some(valid_captures) =
+            uri_to_basename(uri).and_then(|base| options.valid_captures.get(&base))
+        {
+            completion_items.extend(valid_captures.iter().map(|cap| {
+                let label = "@".to_string() + cap.0;
+                if let Some(CompletionTextEdit::Edit(edit)) = text_edit.as_mut() {
+                    edit.new_text = label.clone();
+                };
+                CompletionItem {
+                    label,
+                    documentation: Some(Documentation::MarkupContent(MarkupContent {
+                        kind: MarkupKind::Markdown,
+                        value: cap.1.clone(),
+                    })),
+                    kind: Some(CompletionItemKind::VARIABLE),
+                    text_edit: text_edit.clone(),
+                    ..Default::default()
+                }
+            }));
         }
     }
 
@@ -168,13 +213,16 @@ pub async fn completion(
 
 #[cfg(test)]
 mod test {
+    use std::collections::BTreeMap;
+
     use pretty_assertions::assert_eq;
     use rstest::rstest;
     use tower::{Service, ServiceExt};
     use tower_lsp::lsp_types::{
         CompletionItem, CompletionItemKind, CompletionParams, CompletionResponse,
-        PartialResultParams, Position, TextDocumentIdentifier, TextDocumentPositionParams,
-        WorkDoneProgressParams, request::Completion,
+        CompletionTextEdit, MarkupContent, MarkupKind, PartialResultParams, Position, Range,
+        TextDocumentIdentifier, TextDocumentPositionParams, TextEdit, WorkDoneProgressParams,
+        request::Completion,
     };
 
     use crate::{
@@ -193,7 +241,19 @@ mod test {
         &[SymbolInfo { label: String::from("identifier"), named: true }],
         &["operator"],
         &["supertype"],
-        &[("@constant", CompletionItemKind::VARIABLE)]
+        None,
+        &[CompletionItem {
+            label: String::from("@constant"),
+            kind: Some(CompletionItemKind::VARIABLE),
+            text_edit: Some(CompletionTextEdit::Edit(TextEdit {
+                new_text: String::from("@constant"),
+                range: Range {
+                    start: Position { line: 1, character: 9 },
+                    end: Position { line: 1, character: 14 },
+                }
+            })),
+            ..Default::default()
+        }],
     )]
     #[case(
         r#"((ident) @constant
@@ -202,10 +262,23 @@ mod test {
         &[SymbolInfo { label: String::from("identifier"), named: true }],
         &["operator"],
         &["supertype"],
+        None,
         &[
-            ("identifier", CompletionItemKind::CLASS),
-            ("MISSING", CompletionItemKind::KEYWORD),
-            ("operator: ", CompletionItemKind::FIELD),
+            CompletionItem {
+                label: String::from("identifier"),
+                kind: Some(CompletionItemKind::CLASS),
+                ..Default::default()
+            },
+            CompletionItem {
+                label: String::from("MISSING"),
+                kind: Some(CompletionItemKind::KEYWORD),
+                ..Default::default()
+            },
+            CompletionItem {
+                label: String::from("operator: "),
+                kind: Some(CompletionItemKind::FIELD),
+                ..Default::default()
+            },
         ]
     )]
     #[case(
@@ -217,6 +290,7 @@ mod test {
         &[SymbolInfo { label: String::from("constant"), named: true }],
         &["operator"],
         &["supertype"],
+        None,
         &[]
     )]
     #[case(
@@ -225,9 +299,98 @@ mod test {
         &[SymbolInfo { label: String::from("constant"), named: true }],
         &["operator"],
         &["supertype"],
+        None,
         &[
-            ("test", CompletionItemKind::CLASS),
-            ("test2", CompletionItemKind::CLASS),
+            CompletionItem {
+                label: String::from("test"),
+                kind: Some(CompletionItemKind::CLASS),
+                ..Default::default()
+            },
+            CompletionItem {
+                label: String::from("test2"),
+                kind: Some(CompletionItemKind::CLASS),
+                ..Default::default()
+            },
+        ]
+    )]
+    #[case(
+        r"(constant) @cons ",
+        Position { line: 0, character: 13 },
+        &[SymbolInfo { label: String::from("constant"), named: true }],
+        &["operator"],
+        &["supertype"],
+        Some(BTreeMap::from([(String::from("constant"), String::from("a constant"))])),
+        &[
+            CompletionItem {
+                label: String::from("@constant"),
+                kind: Some(CompletionItemKind::VARIABLE),
+                documentation: Some(tower_lsp::lsp_types::Documentation::MarkupContent(MarkupContent {
+                    kind: MarkupKind::Markdown,
+                    value: String::from("a constant"),
+                })),
+                text_edit: Some(CompletionTextEdit::Edit(TextEdit { range: Range { start: Position
+                    { line: 0, character: 11 }, end: Position { line: 0, character: 16 } },
+                    new_text: String::from("@constant") })),
+                ..Default::default()
+            },
+        ]
+    )]
+    #[case(
+        r"(constant) @ ",
+        Position { line: 0, character: 12 },
+        &[SymbolInfo { label: String::from("constant"), named: true }],
+        &["operator"],
+        &["supertype"],
+        Some(BTreeMap::from([(String::from("constant"), String::from("a constant"))])),
+        &[
+            CompletionItem {
+                label: String::from("@constant"),
+                kind: Some(CompletionItemKind::VARIABLE),
+                documentation: Some(tower_lsp::lsp_types::Documentation::MarkupContent(MarkupContent {
+                    kind: MarkupKind::Markdown,
+                    value: String::from("a constant"),
+                })),
+                text_edit: Some(CompletionTextEdit::Edit(TextEdit { range: Range { start: Position
+                    { line: 0, character: 11 }, end: Position { line: 0, character: 12 } },
+                    new_text: String::from("@constant") })),
+                ..Default::default()
+            },
+        ]
+    )]
+    #[case(
+        r"( (constant) @constant (#eq? @) ) ",
+        Position { line: 0, character: 30 },
+        &[SymbolInfo { label: String::from("constant"), named: true }],
+        &["operator"],
+        &["supertype"],
+        Some(BTreeMap::from([(String::from("constant"), String::from("a constant"))])),
+        &[
+            CompletionItem {
+                label: String::from("@constant"),
+                kind: Some(CompletionItemKind::VARIABLE),
+                text_edit: Some(CompletionTextEdit::Edit(TextEdit {
+                    range: Range { start: Position { line: 0, character: 29 }, end: Position { line: 0, character: 30 } },
+                    new_text: String::from("@constant") })),
+                ..Default::default()
+            },
+        ]
+    )]
+    #[case(
+        r"( (constant) @constant (#eq? @cons) ) ",
+        Position { line: 0, character: 34 },
+        &[SymbolInfo { label: String::from("constant"), named: true }],
+        &["operator"],
+        &["supertype"],
+        Some(BTreeMap::from([(String::from("constant"), String::from("a constant"))])),
+        &[
+            CompletionItem {
+                label: String::from("@constant"),
+                kind: Some(CompletionItemKind::VARIABLE),
+                text_edit: Some(CompletionTextEdit::Edit(TextEdit {
+                    range: Range { start: Position { line: 0, character: 29 }, end: Position { line: 0, character: 34 } },
+                    new_text: String::from("@constant") })),
+                ..Default::default()
+            },
         ]
     )]
     #[tokio::test(flavor = "current_thread")]
@@ -237,7 +400,8 @@ mod test {
         #[case] symbols: &[SymbolInfo],
         #[case] fields: &[&str],
         #[case] supertypes: &[&str],
-        #[case] expected_completions: &[(&str, CompletionItemKind)],
+        #[case] valid_captures: Option<BTreeMap<String, String>>,
+        #[case] expected_completions: &[CompletionItem],
     ) {
         // Arrange
         let mut service = initialize_server(
@@ -248,7 +412,7 @@ mod test {
                 fields.to_vec(),
                 supertypes.to_vec(),
             )],
-            None,
+            valid_captures,
         )
         .await;
 
@@ -278,16 +442,7 @@ mod test {
         let actual_completions = if expected_completions.is_empty() {
             None
         } else {
-            Some(CompletionResponse::Array(
-                expected_completions
-                    .iter()
-                    .map(|c| CompletionItem {
-                        label: c.0.to_string(),
-                        kind: Some(c.1),
-                        ..Default::default()
-                    })
-                    .collect(),
-            ))
+            Some(CompletionResponse::Array(expected_completions.to_vec()))
         };
         assert_eq!(
             completions,

--- a/src/handlers/diagnostic.rs
+++ b/src/handlers/diagnostic.rs
@@ -358,7 +358,7 @@ mod test {
             .iter()
             .map(|s| (s.to_string(), Default::default()))
             .collect();
-        let allowable_captures = Some(&binding);
+        let valid_captures = Some(&binding);
         let symbols = &HashSet::from_iter(symbols.iter().cloned());
         let fields = &HashSet::from_iter(fields.iter().map(|s| s.to_string()));
 
@@ -370,7 +370,7 @@ mod test {
             symbols,
             fields,
             &Default::default(),
-            allowable_captures,
+            valid_captures,
         );
 
         // Assert

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,7 +45,11 @@ static SERVER_CAPABILITIES: LazyLock<ServerCapabilities> = LazyLock::new(|| {
         definition_provider: Some(OneOf::Left(true)),
         document_formatting_provider: Some(OneOf::Left(true)),
         completion_provider: Some(CompletionOptions {
-            trigger_characters: Some(["@", "\"", "\\", "(", "/"].map(ToOwned::to_owned).into()),
+            trigger_characters: Some(
+                ["@", "\"", "\\", "(", "/", "."]
+                    .map(ToOwned::to_owned)
+                    .into(),
+            ),
             ..CompletionOptions::default()
         }),
         document_highlight_provider: Some(OneOf::Left(true)),

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -69,7 +69,7 @@ pub mod helpers {
     /// Always test with id of 1 for simplicity
     const ID: i64 = 1;
 
-    /// A tuple holding the document's URI, source text, symbols, fields, supertypes, and allowable
+    /// A tuple holding the document's URI, source text, symbols, fields, supertypes, and valid
     /// captures
     pub type Document<'a> = (Url, &'a str, Vec<SymbolInfo>, Vec<&'a str>, Vec<&'a str>);
 


### PR DESCRIPTION
This commit also improves the existing capture completions by adding `TextEdit` support, meaning there are no longer any dodgy semantics regarding whether or not the completion should slurp up the preceding `@` sign.