### PR TITLE
fix(formatter): correct blank MISSING node format

### DIFF
--- a/queries/formatting_test_files/after_missing.scm
+++ b/queries/formatting_test_files/after_missing.scm
@@ -1,3 +1,8 @@
 (MISSING "somenode") @missing
 
 (cap) @node
+
+(function
+  (MISSING)) @missingfunc
+
+(MISSING)

--- a/queries/formatting_test_files/before_complex.scm
+++ b/queries/formatting_test_files/before_complex.scm
@@ -6,7 +6,9 @@
 ;                         Basic highlights                         ;;
 ;------------------------------------------------------------------;;
 ; basic ;;
-(number) @number
+(((
+  (((
+    (number))))))) @number
 
 ; format-ignore
 (   character   )

--- a/queries/formatting_test_files/before_missing.scm
+++ b/queries/formatting_test_files/before_missing.scm
@@ -1,2 +1,9 @@
  ( MISSING    "somenode" )    @missing
  (cap) @node
+
+
+(function
+   (   MISSING  
+   ) ) @missingfunc
+
+(   MISSING )

--- a/src/handlers/formatting.rs
+++ b/src/handlers/formatting.rs
@@ -235,7 +235,7 @@ fn format_iter<'a>(
                 }
             } else if map.get("format.make-pound").unwrap().contains_key(id) {
                 lines.last_mut().unwrap().push('#');
-            } else if child.named_child_count() == 0 || child.kind() == "string" {
+            } else if child.child_count() == 0 {
                 let text = NEWLINES
                     .split(
                         CRLF.replace_all(child.text(rope).as_str(), "\n")


### PR DESCRIPTION
The problem was we only stopped recurring when a node had no *named* children. A blank MISSING node, however, has no named children but a few unnamed children. This meant the entire node was treated as one "string unit" so spaces inside it weren't being collapsed. This commit fixes the formatter logic and adds some more test cases for this.