### PR TITLE
fix(formatter): fix subcommand, string formatting

### DIFF
--- a/queries/formatting_test_files/after_complex.scm
+++ b/queries/formatting_test_files/after_complex.scm
@@ -688,3 +688,7 @@
 
 ((sexp_comment) @comment
   (#set! priority 110))
+
+(normal_command
+  (identifier) @_function
+  (#match? @_function "\\c^list$"))

--- a/queries/formatting_test_files/before_complex.scm
+++ b/queries/formatting_test_files/before_complex.scm
@@ -642,4 +642,6 @@
 
 
 
-
+(normal_command
+   (identifier) @_function
+   (#match? @_function "\\c^list$"))

--- a/src/handlers/formatting.rs
+++ b/src/handlers/formatting.rs
@@ -234,7 +234,9 @@ fn format_iter<'a>(
                 }
             } else if map.get("format.make-pound").unwrap().contains_key(id) {
                 lines.last_mut().unwrap().push('#');
-            } else if child.child_count() == 0 {
+            // Stop recursively formatting on leaf nodes (or strings, which should not have their
+            // inner content touched)
+            } else if child.child_count() == 0 || child.kind() == "string" {
                 let text = NEWLINES
                     .split(
                         CRLF.replace_all(child.text(rope).as_str(), "\n")

--- a/src/main.rs
+++ b/src/main.rs
@@ -282,8 +282,6 @@ fn format_directories(directories: &[PathBuf], check: bool) -> i32 {
             let tree = parser.parse(contents.as_str(), None).unwrap();
             let rope = Rope::from(contents.as_str());
             if let Some(formatted) = formatting::format_document(&rope, &tree) {
-                // Add newline at EOF
-                let formatted = formatted + "\n";
                 if check {
                     let edits = formatting::diff(&contents, &formatted, &rope);
                     if !edits.is_empty() {


### PR DESCRIPTION
`format` applied a final newline to files before the actual formatter did so. Now it does, but we must remove the `format` patch lest two newlines be applied to files.

Additionally, strings should go back to having their inner content untouched, as they can have other named nodes inside them, like escape sequences.