### PR TITLE
feat(test): CLI format test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -525,7 +525,6 @@ checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
 dependencies = [
  "futures-channel",
  "futures-core",
- "futures-executor",
  "futures-io",
  "futures-sink",
  "futures-task",
@@ -547,17 +546,6 @@ name = "futures-core"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
-
-[[package]]
-name = "futures-executor"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
-dependencies = [
- "futures-core",
- "futures-task",
- "futures-util",
-]
 
 [[package]]
 name = "futures-io"
@@ -1202,21 +1190,21 @@ dependencies = [
 
 [[package]]
 name = "rstest"
-version = "0.23.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a2c585be59b6b5dd66a9d2084aa1d8bd52fbdb806eafdeffb52791147862035"
+checksum = "6fc39292f8613e913f7df8fa892b8944ceb47c247b78e1b1ae2f09e019be789d"
 dependencies = [
- "futures",
  "futures-timer",
+ "futures-util",
  "rstest_macros",
  "rustc_version",
 ]
 
 [[package]]
 name = "rstest_macros"
-version = "0.23.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "825ea780781b15345a146be27eaefb05085e337e869bff01b4306a4fd4a9ad5a"
+checksum = "1f168d99749d307be9de54d23fd226628d99768225ef08f6ffb52e0182a27746"
 dependencies = [
  "cfg-if",
  "glob",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,5 +42,5 @@ cc = "1.1.30"
 
 [dev-dependencies]
 pretty_assertions = "1.4.1"
-rstest = "0.23.0"
+rstest = "0.25.0"
 tower = { version = "0.5.1", features = ["util"] }

--- a/tests/format.rs
+++ b/tests/format.rs
@@ -1,0 +1,48 @@
+#[cfg(test)]
+mod test {
+    use rstest::{Context, rstest};
+    use std::{env::temp_dir, fs, process::Command};
+
+    #[rstest]
+    #[case(
+        include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/queries/formatting_test_files/before_trailing_whitespace.scm")),
+        include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/queries/formatting_test_files/after_trailing_whitespace.scm")),
+    )]
+    #[case(
+        include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/queries/formatting_test_files/before_predicates.scm")),
+        include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/queries/formatting_test_files/after_predicates.scm")),
+    )]
+    #[case(
+        include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/queries/formatting_test_files/before_missing.scm")),
+        include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/queries/formatting_test_files/after_missing.scm")),
+    )]
+    #[case(
+        include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/queries/formatting_test_files/before_syntax_error.scm")),
+        include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/queries/formatting_test_files/after_syntax_error.scm")),
+    )]
+    #[case(
+        include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/queries/formatting_test_files/before_complex.scm")),
+        include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/queries/formatting_test_files/after_complex.scm")),
+    )]
+    fn cli_formatting(#[context] ctx: Context, #[case] before: &str, #[case] after: &str) {
+        // Arrange
+        let path = temp_dir()
+            .join("ts-query-ls")
+            .join(ctx.case.unwrap().to_string())
+            .join("test.scm");
+        fs::create_dir_all(path.parent().unwrap()).expect("Failed to create test case directory");
+        fs::write(&path, before).expect("Failed to write test file");
+
+        // Act
+        Command::new(env!("CARGO_BIN_EXE_ts_query_ls"))
+            .arg("format")
+            .arg(&path)
+            .output()
+            .expect("Failed to wait on ts-query-ls format command");
+
+        // Assert
+        let formatted = fs::read_to_string(&path).expect("Failed to read test file");
+        _ = fs::remove_file(path); // ignore cleanup errors
+        assert_eq!(after, formatted);
+    }
+}


### PR DESCRIPTION
This adds some basic CLI formatting tests as discussed in #94.

I held off on adding tests for the `check` and `lint` subcommands because I wasn't sure exactly what we'd want to test against and what the corpus should look like. Should we be checking the raw text output? Exit code? I'm ok with whatever, but thought it warranted a discussion first. The same goes for `format --check`.

I bumped the `rstest` dependency from 0.23.0 to 0.25.0 to access the `context` macro. This was useful in giving each test case its own isolated test directory. This isn't strictly necessary, but added it for the following reasons
- Good basic hygiene - Different test cases shouldn't have a chance of interacting with one another.
- If we want to add a test case for formatting directories instead of single files, then this will be necessary.

I added `build_cli` inside `helpers`. Every CLI test will call this on start to build the project before running. Only one test thread wins the race and builds the project, while the others wait. We could instead just have all of the test cases invoke a command with `cargo run -- <subcommand>`, but that was slower and looked kind of ugly. (I had a screenshot but github won't let me paste it in here) Perfectly ok with removing this if you think it's not worth the extra complexity. :)

I also duplicated the rstest `case`s between `cli_formatting` and `server_formatting`. I think there's a way to [de-duplicate](https://github.com/la10736/rstest#use-parametrize-definition-in-more-tests) these with the [rstest-reuse crate](https://crates.io/crates/rstest_reuse). Happy to take a pass at this if you think it's worth the extra dev dependency.

Edit: Ok last force push before review I swear.