### PR TITLE
chore: prune dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -458,29 +458,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
-name = "env_filter"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2c92ceda6ceec50f43169f9ee8424fe2db276791afde7b2cd8bc084cb376ab"
-dependencies = [
- "log",
- "regex",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.11.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13fa619b91fb2381732789fc5de83b45675e882f66623b7d8cb4f643017018d"
-dependencies = [
- "anstream",
- "anstyle",
- "env_filter",
- "humantime",
- "log",
-]
-
-[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -659,12 +636,6 @@ name = "httparse"
 version = "1.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d71d3574edd2771538b901e6549113b4006ece66150fb69c0fb6d9a2adae946"
-
-[[package]]
-name = "humantime"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "icu_collections"
@@ -1737,7 +1708,6 @@ dependencies = [
  "clap",
  "dashmap 6.1.0",
  "dissimilar",
- "env_logger",
  "libloading",
  "pretty_assertions",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,16 +16,20 @@ members = [
 [lib]
 path = "src/lib.rs"
 
+# Only include schemars in the schema generation xtask, so as to reduce binary
+# size
+[features]
+schema = ["schemars"]
+
 [dependencies]
 clap = { version = "4.5.31", features = ["derive"] }
 dashmap = "6.1.0"
 dissimilar = "1.0.9"
-env_logger = "0.11.5"
 libloading = "0.8.5"
 rayon = "1.10.0"
 regex = "1.11.0"
 ropey = "1.6.1"
-schemars = "0.8.22"
+schemars = { version = "0.8.22", optional = true, features = ["derive"] }
 serde = "1.0.210"
 serde_json = "1.0.132"
 streaming-iterator = "0.1.9"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,16 +4,18 @@ use std::{
     fmt::Display,
 };
 
+#[cfg(feature = "schema")]
 use schemars::JsonSchema;
 use serde::{Deserialize, Deserializer, Serialize};
 
 /// A type specification for a predicate.
-#[derive(Clone, Debug, PartialEq, Eq, Default, JsonSchema, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
 struct PredicateAux {
     /// A short description of the predicate (in Markdown format).
     description: String,
     /// The list of valid parameter types.
-    #[schemars(length(min = 1))]
+    #[cfg_attr(feature = "schema", schemars(length(min = 1)))]
     parameters: Vec<PredicateParameter>,
     /// Whether this predicate supports a `not-` prefixed variant. Defaults to `true`.
     #[serde(default = "default_true")]
@@ -96,7 +98,8 @@ where
 }
 
 /// Configuration options for the language server.
-#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Default, JsonSchema, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Default, Clone)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
 pub struct Options {
     /// A list of strings representing directories to search for parsers, of the form
     /// `<lang>.(so|dll|dylib)` or `tree-sitter-<lang>.wasm`.
@@ -119,25 +122,27 @@ pub struct Options {
     pub valid_captures: HashMap<String, BTreeMap<String, String>>,
     /// A map of predicate names (sans `#` and `?`) to parameter specifications.
     #[serde(default, deserialize_with = "add_prefixes")]
-    #[schemars(schema_with = "prefixes_schema")]
+    #[cfg_attr(feature = "schema", schemars(schema_with = "prefixes_schema"))]
     pub valid_predicates: BTreeMap<String, Predicate>,
     /// A map of directive names (sans `#` and `!`) to parameter specifications.
     #[serde(default)]
     pub valid_directives: BTreeMap<String, Predicate>,
 }
 
+#[cfg(feature = "schema")]
 fn prefixes_schema(gen_: &mut schemars::r#gen::SchemaGenerator) -> schemars::schema::Schema {
     let raw = <BTreeMap<String, PredicateAux>>::json_schema(gen_).into_object();
     raw.into()
 }
 
 /// A type specification for a directive.
-#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Default, JsonSchema, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Default, Clone)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
 pub struct Predicate {
     /// A short description of the predicate (in Markdown format).
     pub description: String,
     /// The list of valid parameter types.
-    #[schemars(length(min = 1))]
+    #[cfg_attr(feature = "schema", schemars(length(min = 1)))]
     pub parameters: Vec<PredicateParameter>,
 }
 
@@ -145,7 +150,8 @@ pub struct Predicate {
 ///
 /// Parameters can be one or both of two types (a capture or a string), and can be required,
 /// optional, or "variadic" (there can be zero-to-many of them).
-#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, JsonSchema, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
 pub struct PredicateParameter {
     /// An optional description of this parameter.
     pub description: Option<String>,
@@ -159,7 +165,8 @@ pub struct PredicateParameter {
 }
 
 /// The type of the predicate parameter.
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, JsonSchema, Clone)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[serde(rename_all = "lowercase")]
 pub enum PredicateParameterType {
     /// Must be a capture (e.g. `@variable`).
@@ -181,7 +188,8 @@ impl Display for PredicateParameterType {
 }
 
 /// The arity of the predicate parameter.
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, JsonSchema, Clone)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[serde(rename_all = "lowercase")]
 pub enum PredicateParameterArity {
     /// A regular, required parameter.

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -7,4 +7,4 @@ edition = "2024"
 clap = { version = "4.5.37", features = ["derive"] }
 schemars = "0.8.22"
 serde_json = "1.0.140"
-ts_query_ls = { path = ".." }
+ts_query_ls = { path = "..", features = ["schema"] }


### PR DESCRIPTION
Removes an old, unused dependency and only includes schemars in the xtask builds (as it is only used for schema generation)