### PR TITLE
Impossible pattern diagnostics

### DIFF
--- a/queries/query/diagnostics.scm
+++ b/queries/query/diagnostics.scm
@@ -2,6 +2,9 @@
 
 (MISSING) @missing
 
+(program
+  (definition) @definition)
+
 (anonymous_node
   (string
     (string_content) @node.anon))

--- a/src/cli/check.rs
+++ b/src/cli/check.rs
@@ -23,7 +23,11 @@ pub fn check_directories(directories: &[PathBuf], config: String, format: bool, 
     };
     scm_files.par_iter().for_each(|path| {
         let uri = Url::from_file_path(path.canonicalize().unwrap()).unwrap();
-        if let Some(lang) = util::get_language(&uri, &options) {
+        let language = (|| {
+            let name = util::get_language_name(&uri, &options)?;
+            util::get_language(&name, &options)
+        })();
+        if let Some(lang) = language {
             if let Ok(source) = fs::read_to_string(path) {
                 if let Err(err) = Query::new(&lang, source.as_str()) {
                     match err.kind {

--- a/src/cli/lint.rs
+++ b/src/cli/lint.rs
@@ -37,6 +37,7 @@ pub(super) fn lint_file(
         fields_vec: Default::default(),
         supertype_map: Default::default(),
         version: Default::default(),
+        language: Default::default(),
     };
     let provider = &util::TextProviderRope(&doc.rope);
     let diagnostics = get_diagnostics(uri, &doc, options, provider);

--- a/src/cli/lint.rs
+++ b/src/cli/lint.rs
@@ -37,7 +37,7 @@ pub(super) fn lint_file(
         fields_vec: Default::default(),
         supertype_map: Default::default(),
         version: Default::default(),
-        language: Default::default(),
+        language_data: Default::default(),
     };
     let provider = &util::TextProviderRope(&doc.rope);
     let diagnostics = get_diagnostics(uri, &doc, options, provider);

--- a/src/handlers/did_open.rs
+++ b/src/handlers/did_open.rs
@@ -24,7 +24,8 @@ pub async fn did_open(backend: &Backend, params: DidOpenTextDocumentParams) {
     let mut fields_vec: Vec<String> = vec![];
     let mut fields_set: HashSet<String> = HashSet::new();
     let mut supertype_map: HashMap<SymbolInfo, BTreeSet<SymbolInfo>> = HashMap::new();
-    if let Some(lang) = get_language(uri, &*backend.options.read().await) {
+    let language = get_language(uri, &*backend.options.read().await);
+    if let Some(lang) = &language {
         let error_symbol = SymbolInfo {
             label: "ERROR".to_owned(),
             named: true,
@@ -85,6 +86,7 @@ pub async fn did_open(backend: &Backend, params: DidOpenTextDocumentParams) {
             fields_vec,
             supertype_map,
             version,
+            language,
         },
     );
 }

--- a/src/handlers/execute_command.rs
+++ b/src/handlers/execute_command.rs
@@ -42,7 +42,11 @@ async fn check_impossible_patterns(backend: &Backend, params: ExecuteCommandPara
     let rope = &doc.rope;
     let tree = &doc.tree;
     let options = &backend.options.read().await;
-    let Some(lang) = util::get_language(&uri, options) else {
+    let language = (|| {
+        let name = util::get_language_name(&uri, options)?;
+        util::get_language(&name, options)
+    })();
+    let Some(lang) = language else {
         warn!("Could not retrieve language for path: '{}'", uri.path());
         return;
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -102,6 +102,14 @@ impl fmt::Display for SymbolInfo {
     }
 }
 
+#[derive(Clone)]
+pub struct LanguageData {
+    language: Language,
+    // TODO: Once most parsers are upgraded to ABI 15, just get the name from the language object
+    // itself
+    name: String,
+}
+
 struct DocumentData {
     symbols_set: HashSet<SymbolInfo>,
     symbols_vec: Vec<SymbolInfo>,
@@ -111,7 +119,7 @@ struct DocumentData {
     rope: Rope,
     tree: Tree,
     version: i32,
-    language: Option<Language>,
+    language_data: Option<LanguageData>,
 }
 
 struct Backend {

--- a/src/main.rs
+++ b/src/main.rs
@@ -111,6 +111,7 @@ struct DocumentData {
     rope: Rope,
     tree: Tree,
     version: i32,
+    language: Option<Language>,
 }
 
 struct Backend {

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -84,6 +84,7 @@ pub mod helpers {
                                     ]),
                                 )
                             })),
+                            language_data: None,
                         },
                     )
                 },


### PR DESCRIPTION
## Implementation

This will spawn a new query with `Query::new` for every pattern definition in the file. This way we can get more than one impossible pattern diagnostic per file. This creates a lot of overhead, especially for bugged queries that max out the iteration count before terminating analysis (with no helpful results). Thus, we cache the results of the structure analysis by query text and language name. So additional work is only performed when a pattern changes and its analysis is *not* found in the cache.

- Pros:
  - Much faster query analysis, especially with bugged patterns that take forever. Instead of a disrupting delay on every keystroke, we only get a disrupting delay when analyzing a semantically correct, bugged pattern for the first time
- Cons:
  - Memory usage blowing up as time goes on? I haven't noticed this to be an issue at all, but it is theoretically (?) possible, for power users who edit dozens of queries with different languages in one session. Even then, the cache only maintains structure error byte offsets, not the whole query error struct, so the footprint is as minimal as possible.

cc @WillLillis. Do you see any issues with this approach? Do you think this looks good?

## TODO

- [ ] Use these diagnostics in `check` subcommand, eliminate manual `Query::new` step
- [ ] Remove impossible patterns code action?
- [ ] Wrap query constructions in `spawn_blocking`?
    - For very small, easy to analyze patterns, this will likely be more overhead than it is worth. However for certain bugged patterns, it takes 1-2 whole seconds to analyze. This gives a very noticeable delay when saving/requesting completions. So should this be done? We already cache the results so... :man_shrugging:  