### PR TITLE
refactor: extract language data into a separate struct

### DIFF
--- a/src/handlers/did_open.rs
+++ b/src/handlers/did_open.rs
@@ -6,7 +6,7 @@ use tracing::info;
 use tree_sitter::Parser;
 
 use crate::{
-    Backend, DocumentData, QUERY_LANGUAGE, SymbolInfo,
+    Backend, DocumentData, LanguageData, QUERY_LANGUAGE, SymbolInfo,
     util::{get_language, get_language_name},
 };
 
@@ -21,77 +21,92 @@ pub async fn did_open(backend: &Backend, params: DidOpenTextDocumentParams) {
         .expect("Error loading Query grammar");
     let tree = parser.parse(&contents, None).unwrap();
 
+    let options = backend.options.read().await;
+    let language_name = get_language_name(uri, &options);
+
+    // Track the document
+    let version = params.text_document.version;
+    backend.document_map.insert(
+        uri.clone(),
+        DocumentData {
+            rope,
+            tree,
+            language_name: language_name.clone(),
+            version,
+        },
+    );
+
     // Initialize language info
     let mut symbols_vec: Vec<SymbolInfo> = vec![];
     let mut symbols_set: HashSet<SymbolInfo> = HashSet::new();
     let mut fields_vec: Vec<String> = vec![];
     let mut fields_set: HashSet<String> = HashSet::new();
     let mut supertype_map: HashMap<SymbolInfo, BTreeSet<SymbolInfo>> = HashMap::new();
-    let options = backend.options.read().await;
-    let language_name = get_language_name(uri, &options);
-    if let Some(lang) = language_name.and_then(|name| get_language(&name, &options)) {
-        let error_symbol = SymbolInfo {
-            label: "ERROR".to_owned(),
-            named: true,
+    let language_name = match language_name {
+        Some(name) => name,
+        None => return,
+    };
+    if backend.language_map.contains_key(&language_name) {
+        return;
+    }
+    let Some(lang) = get_language(&language_name, &options) else {
+        return;
+    };
+    let error_symbol = SymbolInfo {
+        label: "ERROR".to_owned(),
+        named: true,
+    };
+    symbols_set.insert(error_symbol.clone());
+    symbols_vec.push(error_symbol);
+    for i in 0..lang.node_kind_count() as u16 {
+        let supertype = lang.node_kind_is_supertype(i);
+        let named = lang.node_kind_is_named(i) || supertype;
+        let label = if named {
+            lang.node_kind_for_id(i).unwrap().to_owned()
+        } else {
+            lang.node_kind_for_id(i)
+                .unwrap()
+                .replace('\\', r"\\")
+                .replace('"', r#"\""#)
+                .replace('\n', r"\n")
         };
-        symbols_set.insert(error_symbol.clone());
-        symbols_vec.push(error_symbol);
-        for i in 0..lang.node_kind_count() as u16 {
-            let supertype = lang.node_kind_is_supertype(i);
-            let named = lang.node_kind_is_named(i) || supertype;
-            let label = if named {
-                lang.node_kind_for_id(i).unwrap().to_owned()
-            } else {
-                lang.node_kind_for_id(i)
-                    .unwrap()
-                    .replace('\\', r"\\")
-                    .replace('"', r#"\""#)
-                    .replace('\n', r"\n")
-            };
-            let symbol_info = SymbolInfo { label, named };
-            if supertype {
-                supertype_map.insert(
-                    symbol_info.clone(),
-                    lang.subtypes_for_supertype(i)
-                        .iter()
-                        .map(|s| SymbolInfo {
-                            label: lang.node_kind_for_id(*s).unwrap().to_string(),
-                            named: lang.node_kind_is_named(*s) || lang.node_kind_is_supertype(*s),
-                        })
-                        .collect(),
-                );
-            }
-            if symbols_set.contains(&symbol_info) || !(lang.node_kind_is_visible(i) || supertype) {
-                continue;
-            }
-            symbols_set.insert(symbol_info.clone());
-            symbols_vec.push(symbol_info);
+        let symbol_info = SymbolInfo { label, named };
+        if supertype {
+            supertype_map.insert(
+                symbol_info.clone(),
+                lang.subtypes_for_supertype(i)
+                    .iter()
+                    .map(|s| SymbolInfo {
+                        label: lang.node_kind_for_id(*s).unwrap().to_string(),
+                        named: lang.node_kind_is_named(*s) || lang.node_kind_is_supertype(*s),
+                    })
+                    .collect(),
+            );
         }
-        // Field IDs go from 1 to nfields inclusive (extra index 0 maps to NULL)
-        for i in 1..=lang.field_count() as u16 {
-            let field_name = lang.field_name_for_id(i).unwrap().to_owned();
-            if !fields_set.contains(&field_name) {
-                fields_set.insert(field_name.clone());
-                fields_vec.push(field_name);
-            }
+        if symbols_set.contains(&symbol_info) || !(lang.node_kind_is_visible(i) || supertype) {
+            continue;
+        }
+        symbols_set.insert(symbol_info.clone());
+        symbols_vec.push(symbol_info);
+    }
+    // Field IDs go from 1 to nfields inclusive (extra index 0 maps to NULL)
+    for i in 1..=lang.field_count() as u16 {
+        let field_name = lang.field_name_for_id(i).unwrap().to_owned();
+        if !fields_set.contains(&field_name) {
+            fields_set.insert(field_name.clone());
+            fields_vec.push(field_name);
         }
     }
-
-    let version = params.text_document.version;
-
-    backend.document_map.insert(
-        uri.clone(),
-        DocumentData {
-            rope,
-            tree,
-            symbols_set,
-            symbols_vec,
-            fields_set,
-            fields_vec,
-            supertype_map,
-            version,
-        },
-    );
+    let language_data = LanguageData {
+        fields_set,
+        fields_vec,
+        symbols_vec,
+        symbols_set,
+        supertype_map,
+    };
+    backend
+        .language_map
+        .insert(language_name, language_data.into());
 }
 
 #[cfg(test)]

--- a/src/handlers/execute_command.rs
+++ b/src/handlers/execute_command.rs
@@ -86,7 +86,19 @@ async fn check_impossible_patterns(backend: &Backend, params: ExecuteCommandPara
         }
     }
     let provider = &TextProviderRope(rope);
-    diagnostics.append(&mut get_diagnostics(&uri, doc, options, provider));
+    let language_data = doc
+        .language_name
+        .as_ref()
+        .and_then(|name| backend.language_map.get(name))
+        .as_deref()
+        .cloned();
+    diagnostics.append(&mut get_diagnostics(
+        &uri,
+        doc,
+        language_data,
+        options,
+        provider,
+    ));
 
     backend
         .client

--- a/src/handlers/initialize.rs
+++ b/src/handlers/initialize.rs
@@ -66,6 +66,7 @@ mod test {
         let (mut service, _socket) = LspService::build(|client| Backend {
             client,
             document_map: Default::default(),
+            language_map: Default::default(),
             workspace_uris: Default::default(),
             options: Default::default(),
         })


### PR DESCRIPTION
This decouples language information from document information, reducing memory in the case that multiple documents are open which all share the same query language. This refactor also makes it easier to share the language object in the future.