### PR TITLE
refactor: make diagnostics thread safe

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -359,25 +359,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-deque"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
-dependencies = [
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-utils"
 version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -502,6 +483,7 @@ checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
 dependencies = [
  "futures-channel",
  "futures-core",
+ "futures-executor",
  "futures-io",
  "futures-sink",
  "futures-task",
@@ -523,6 +505,17 @@ name = "futures-core"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
 
 [[package]]
 name = "futures-io"
@@ -1069,26 +1062,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
-]
-
-[[package]]
-name = "rayon"
-version = "1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
-dependencies = [
- "either",
- "rayon-core",
-]
-
-[[package]]
-name = "rayon-core"
-version = "1.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
-dependencies = [
- "crossbeam-deque",
- "crossbeam-utils",
 ]
 
 [[package]]
@@ -1696,9 +1669,9 @@ dependencies = [
  "clap",
  "dashmap 6.1.0",
  "dissimilar",
+ "futures",
  "libloading",
  "pretty_assertions",
- "rayon",
  "regex",
  "ropey",
  "rstest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,8 +25,8 @@ schema = ["schemars"]
 clap = { version = "4.5.31", features = ["derive"] }
 dashmap = "6.1.0"
 dissimilar = "1.0.9"
+futures = "0.3.31"
 libloading = "0.8.5"
-rayon = "1.10.0"
 regex = "1.11.0"
 ropey = "1.6.1"
 schemars = { version = "0.8.22", optional = true, features = ["derive"] }

--- a/src/cli/format.rs
+++ b/src/cli/format.rs
@@ -1,48 +1,58 @@
-use std::{fs, path::PathBuf, sync::atomic::AtomicI32};
+use std::{
+    fs,
+    path::PathBuf,
+    sync::{Arc, atomic::AtomicI32},
+};
 
-use rayon::iter::{IntoParallelRefIterator as _, ParallelIterator as _};
+use futures::future::join_all;
 use ropey::Rope;
+use tokio::task::spawn_blocking;
 
 use crate::{QUERY_LANGUAGE, handlers::formatting};
 
 use super::get_scm_files;
 
-pub fn format_directories(directories: &[PathBuf], check: bool) -> i32 {
+pub async fn format_directories(directories: &[PathBuf], check: bool) -> i32 {
     if directories.is_empty() {
         eprintln!("No directories were specified to be formatted. No work was done.");
         return 1;
     }
 
     let scm_files = get_scm_files(directories);
-    let exit_code = AtomicI32::new(0);
+    let exit_code = Arc::new(AtomicI32::new(0));
 
-    scm_files.par_iter().for_each(|path| {
-        if let Ok(contents) = fs::read_to_string(path) {
+    let tasks = scm_files.into_iter().filter_map(|path| {
+        let exit_code = exit_code.clone();
+        if let Ok(contents) = fs::read_to_string(&path) {
             let mut parser = tree_sitter::Parser::new();
             parser
                 .set_language(&QUERY_LANGUAGE)
                 .expect("Error loading Query grammar");
             let tree = parser.parse(contents.as_str(), None).unwrap();
             let rope = Rope::from(contents.as_str());
-            if let Some(formatted) = formatting::format_document(&rope, &tree.root_node()) {
-                if check {
-                    let edits = formatting::diff(&contents, &formatted, &rope);
-                    if !edits.is_empty() {
+            return Some(spawn_blocking(move || {
+                if let Some(formatted) = formatting::format_document(&rope, &tree.root_node()) {
+                    if check {
+                        let edits = formatting::diff(&contents, &formatted, &rope);
+                        if !edits.is_empty() {
+                            exit_code.store(1, std::sync::atomic::Ordering::Relaxed);
+                            eprintln!(
+                                "Improper formatting detected for {:?}",
+                                path.canonicalize().unwrap()
+                            );
+                        }
+                    } else if fs::write(&path, formatted).is_err() {
                         exit_code.store(1, std::sync::atomic::Ordering::Relaxed);
-                        eprintln!(
-                            "Improper formatting detected for {:?}",
-                            path.canonicalize().unwrap()
-                        );
+                        eprint!("Failed to write to {:?}", path.canonicalize().unwrap())
                     }
-                } else if fs::write(path, formatted).is_err() {
-                    exit_code.store(1, std::sync::atomic::Ordering::Relaxed);
-                    eprint!("Failed to write to {:?}", path.canonicalize().unwrap())
                 }
-            }
+            }));
         } else {
             eprintln!("Failed to read {:?}", path.canonicalize().unwrap());
             exit_code.store(1, std::sync::atomic::Ordering::Relaxed);
         }
+        None
     });
+    join_all(tasks).await;
     exit_code.load(std::sync::atomic::Ordering::Relaxed)
 }

--- a/src/cli/lint.rs
+++ b/src/cli/lint.rs
@@ -10,9 +10,7 @@ use tower_lsp::lsp_types::{DiagnosticSeverity, Url};
 use ts_query_ls::Options;
 
 use crate::{
-    DocumentData, QUERY_LANGUAGE,
-    handlers::diagnostic::get_diagnostics,
-    util::{self, get_language_name},
+    DocumentData, QUERY_LANGUAGE, handlers::diagnostic::get_diagnostics, util::get_language_name,
 };
 
 use super::get_scm_files;
@@ -37,10 +35,9 @@ pub(super) fn lint_file(
         language_name,
         version: Default::default(),
     };
-    let provider = &util::TextProviderRope(&doc.rope);
     // The query construction already validates node names, fields, supertypes,
     // etc.
-    let diagnostics = get_diagnostics(uri, &doc, None, options, provider);
+    let diagnostics = get_diagnostics(uri, &doc, None, options);
     if !diagnostics.is_empty() {
         exit_code.store(1, std::sync::atomic::Ordering::Relaxed);
         for diagnostic in diagnostics {

--- a/src/cli/lint.rs
+++ b/src/cli/lint.rs
@@ -1,10 +1,10 @@
 use std::{
     env, fs,
     path::{Path, PathBuf},
-    sync::atomic::AtomicI32,
+    sync::{Arc, atomic::AtomicI32},
 };
 
-use rayon::iter::{IntoParallelRefIterator as _, ParallelIterator as _};
+use futures::future::join_all;
 use ropey::Rope;
 use tower_lsp::lsp_types::{DiagnosticSeverity, Url};
 use ts_query_ls::Options;
@@ -15,11 +15,11 @@ use crate::{
 
 use super::get_scm_files;
 
-pub(super) fn lint_file(
+pub(super) async fn lint_file(
     path: &Path,
     uri: &Url,
     source: &str,
-    options: &Options,
+    options: Arc<tokio::sync::RwLock<Options>>,
     exit_code: &AtomicI32,
 ) {
     let mut parser = tree_sitter::Parser::new();
@@ -28,7 +28,7 @@ pub(super) fn lint_file(
         .expect("Error loading Query grammar");
     let tree = parser.parse(source, None).unwrap();
     let rope = Rope::from(source);
-    let language_name = get_language_name(uri, options);
+    let language_name = get_language_name(uri, &*options.read().await);
     let doc = DocumentData {
         tree,
         rope,
@@ -37,7 +37,7 @@ pub(super) fn lint_file(
     };
     // The query construction already validates node names, fields, supertypes,
     // etc.
-    let diagnostics = get_diagnostics(uri, &doc, None, options);
+    let diagnostics = get_diagnostics(uri, doc, None, options).await;
     if !diagnostics.is_empty() {
         exit_code.store(1, std::sync::atomic::Ordering::Relaxed);
         for diagnostic in diagnostics {
@@ -63,26 +63,33 @@ pub(super) fn lint_file(
 /// Lint all the given directories according to the given configuration. Linting covers things like
 /// invalid capture names or predicate signatures, but not errors like invalid node names or
 /// impossible patterns.
-pub fn lint_directories(directories: &[PathBuf], config: String) -> i32 {
+pub async fn lint_directories(directories: &[PathBuf], config: String) -> i32 {
     let Ok(options) = serde_json::from_str::<Options>(&config) else {
         eprintln!("Could not parse the provided configuration");
         return 1;
     };
-    let exit_code = AtomicI32::new(0);
+    let options: Arc<tokio::sync::RwLock<Options>> = Arc::new(options.into());
+    let exit_code = Arc::new(AtomicI32::new(0));
     // If directories are not specified, lint all files in the current directory
     let scm_files = if directories.is_empty() {
         get_scm_files(&[env::current_dir().expect("Failed to get current directory")])
     } else {
         get_scm_files(directories)
     };
-    scm_files.par_iter().for_each(|path| {
+    let tasks = scm_files.into_iter().filter_map(|path| {
         let uri = Url::from_file_path(path.canonicalize().unwrap()).unwrap();
-        if let Ok(source) = fs::read_to_string(path) {
-            lint_file(path, &uri, &source, &options, &exit_code);
+        let exit_code = exit_code.clone();
+        let options = options.clone();
+        if let Ok(source) = fs::read_to_string(&path) {
+            Some(tokio::spawn(async move {
+                lint_file(&path, &uri, &source, options, &exit_code).await;
+            }))
         } else {
             eprintln!("Failed to read {:?}", path.canonicalize().unwrap());
             exit_code.store(1, std::sync::atomic::Ordering::Relaxed);
+            None
         }
     });
+    join_all(tasks).await;
     exit_code.load(std::sync::atomic::Ordering::Relaxed)
 }

--- a/src/handlers/diagnostic.rs
+++ b/src/handlers/diagnostic.rs
@@ -47,14 +47,12 @@ pub async fn diagnostic(
         .and_then(|name| backend.language_map.get(name))
         .as_deref()
         .cloned();
-    let rope = &document.rope;
-    let provider = &TextProviderRope(rope);
     Ok(DocumentDiagnosticReportResult::Report(
         DocumentDiagnosticReport::Full(RelatedFullDocumentDiagnosticReport {
             related_documents: None,
             full_document_diagnostic_report: FullDocumentDiagnosticReport {
                 result_id: None,
-                items: get_diagnostics(uri, document, language_data, options, provider),
+                items: get_diagnostics(uri, document, language_data, options),
             },
         }),
     ))
@@ -65,7 +63,6 @@ pub fn get_diagnostics(
     document: &DocumentData,
     language_data: Option<Arc<LanguageData>>,
     options: &Options,
-    provider: &TextProviderRope,
 ) -> Vec<Diagnostic> {
     let valid_captures = options
         .valid_captures
@@ -74,6 +71,7 @@ pub fn get_diagnostics(
     let valid_directives = &options.valid_directives;
     let tree = &document.tree;
     let rope = &document.rope;
+    let provider = &TextProviderRope(rope);
     let symbols = language_data.as_deref().map(|ld| &ld.symbols_set);
     let fields = language_data.as_deref().map(|ld| &ld.fields_set);
     let supertypes = language_data.as_deref().map(|ld| &ld.supertype_map);
@@ -354,7 +352,6 @@ mod test {
         Options, Predicate, PredicateParameter, PredicateParameterArity, PredicateParameterType,
     };
 
-    use crate::util::TextProviderRope;
     use crate::{
         SymbolInfo,
         handlers::diagnostic::get_diagnostics,
@@ -837,11 +834,9 @@ mod test {
             .get(&language_name)
             .as_deref()
             .cloned();
-        let rope = &doc.rope;
-        let provider = &TextProviderRope(rope);
 
         // Act
-        let diagnostics = get_diagnostics(&TEST_URI, doc, language_data, options, provider);
+        let diagnostics = get_diagnostics(&TEST_URI, doc, language_data, options);
 
         // Assert
         assert_eq!(diagnostics, expected_diagnostics)

--- a/src/handlers/execute_command.rs
+++ b/src/handlers/execute_command.rs
@@ -9,7 +9,7 @@ use tree_sitter::{Point, Query, QueryError, QueryErrorKind};
 use crate::{
     Backend,
     handlers::diagnostic::get_diagnostics,
-    util::{self, NodeUtil as _, TextProviderRope},
+    util::{self, NodeUtil as _},
 };
 
 pub async fn execute_command(
@@ -85,20 +85,13 @@ async fn check_impossible_patterns(backend: &Backend, params: ExecuteCommandPara
             }
         }
     }
-    let provider = &TextProviderRope(rope);
     let language_data = doc
         .language_name
         .as_ref()
         .and_then(|name| backend.language_map.get(name))
         .as_deref()
         .cloned();
-    diagnostics.append(&mut get_diagnostics(
-        &uri,
-        doc,
-        language_data,
-        options,
-        provider,
-    ));
+    diagnostics.append(&mut get_diagnostics(&uri, doc, language_data, options));
 
     backend
         .client

--- a/src/main.rs
+++ b/src/main.rs
@@ -292,7 +292,7 @@ async fn main() {
     let args = Arguments::parse();
     match args.commands {
         Some(Commands::Format { directories, check }) => {
-            std::process::exit(format_directories(&directories, check));
+            std::process::exit(format_directories(&directories, check).await);
         }
         Some(Commands::Check {
             directories,
@@ -301,14 +301,14 @@ async fn main() {
             lint,
         }) => {
             let config_str = get_config_str(config);
-            std::process::exit(check_directories(&directories, config_str, format, lint));
+            std::process::exit(check_directories(&directories, config_str, format, lint).await);
         }
         Some(Commands::Lint {
             directories,
             config,
         }) => {
             let config_str = get_config_str(config);
-            std::process::exit(lint_directories(&directories, config_str))
+            std::process::exit(lint_directories(&directories, config_str).await)
         }
         None => {}
     }
@@ -316,7 +316,7 @@ async fn main() {
     let stdin = tokio::io::stdin();
     let stdout = tokio::io::stdout();
 
-    let options = Arc::new(tokio::sync::RwLock::new(Options::default()));
+    let options = Arc::new(Options::default().into());
     let (service, socket) = LspService::build(|client| {
         let lsp_layer = LspLogLayer::new(client.clone());
         tracing_subscriber::registry().with(lsp_layer).init();

--- a/tests/format.rs
+++ b/tests/format.rs
@@ -86,12 +86,14 @@ mod test {
         // Assert
         if valid {
             assert!(output.stderr.is_empty());
+            assert_eq!(output.status.code(), Some(0));
         } else {
             assert!(
                 String::from_utf8(output.stderr)
                     .unwrap()
                     .contains("Improper formatting detected for")
-            )
+            );
+            assert_eq!(output.status.code(), Some(1));
         }
     }
 }

--- a/tests/lint.rs
+++ b/tests/lint.rs
@@ -73,10 +73,10 @@ mod test {
             for message in messages {
                 assert!(string_output.contains(message));
             }
+            assert_eq!(output.status.code(), Some(1));
         } else {
-            let string_output = String::from_utf8(output.stderr.clone()).unwrap();
-            println!("{string_output}");
             assert!(output.stderr.is_empty());
+            assert_eq!(output.status.code(), Some(0));
         }
     }
 }


### PR DESCRIPTION
This refactor allows the diagnostics to be asynchronous with no worries
of deadlock. This, of course, required a lot of changes because of
function coloring. As such, CLI methods are now asynchronous. This
commit also removes the dependency on `rayon`, and adds the `futures`
crate.