### PR TITLE
fix: account for superfluous escape sequences

### DIFF
--- a/queries/query/diagnostics.scm
+++ b/queries/query/diagnostics.scm
@@ -35,3 +35,5 @@
   name: (identifier) @directive
   (predicate_type) @_type
   (#eq? @_type "!"))
+
+(escape_sequence) @escape

--- a/src/handlers/did_open.rs
+++ b/src/handlers/did_open.rs
@@ -76,6 +76,9 @@ pub fn init_language_data(lang: Language) -> LanguageData {
                 .replace('\\', r"\\")
                 .replace('"', r#"\""#)
                 .replace('\n', r"\n")
+                .replace('\r', r"\r")
+                .replace('\t', r"\t")
+                .replace('\0', r"\0")
         };
         let symbol_info = SymbolInfo { label, named };
         if supertype {


### PR DESCRIPTION
This commit allows node types to be recognized if they have an unnecessary preceding backslash. It also issues a warning that the backslash is not necessary.

See https://github.com/tree-sitter/tree-sitter/blob/31b9717ca3d674d6166f8e4aa17e7927b027c1e1/lib/src/query.c#L2042C7-L2058C8