### PR TITLE
feat: lint for pointless patterns

### DIFF
--- a/src/handlers/code_action.rs
+++ b/src/handlers/code_action.rs
@@ -25,6 +25,7 @@ use crate::{
 pub enum CodeActions {
     RemoveBackslash,
     PrefixUnderscore,
+    Remove,
 }
 
 impl From<CodeActions> for u8 {
@@ -40,6 +41,7 @@ impl TryFrom<u8> for CodeActions {
         match value {
             0 => Ok(CodeActions::RemoveBackslash),
             1 => Ok(CodeActions::PrefixUnderscore),
+            2 => Ok(CodeActions::Remove),
             _ => Err("Invalid value"),
         }
     }
@@ -113,6 +115,23 @@ pub fn diag_to_code_action(
                 ..Default::default()
             }))
         }
+        Ok(CodeActions::Remove) => Some(CodeActionOrCommand::CodeAction(CodeAction {
+            title: String::from("Remove pattern"),
+            kind: Some(CodeActionKind::QUICKFIX),
+            is_preferred: Some(true),
+            edit: Some(WorkspaceEdit {
+                changes: Some(HashMap::from([(
+                    uri.clone(),
+                    vec![TextEdit {
+                        new_text: String::from(""),
+                        range: diagnostic.range,
+                    }],
+                )])),
+                ..Default::default()
+            }),
+            diagnostics: Some(vec![diagnostic]),
+            ..Default::default()
+        })),
         Err(_) => None,
     }
 }

--- a/tests/lint.rs
+++ b/tests/lint.rs
@@ -48,7 +48,7 @@ mod test {
     )]
     #[case(
         concat!(env!("CARGO_MANIFEST_DIR"), "/queries/formatting_test_files/before_missing.scm"),
-        None
+        Some(["This pattern has no captures, and will not be processed"].as_slice())
     )]
     #[case(
         concat!(env!("CARGO_MANIFEST_DIR"), "/queries/formatting_test_files/before_syntax_error.scm"),


### PR DESCRIPTION
This lint also has a quickfix code action to remove it, but it's not advertised in the diagnostic message because it would become too verbose, and it's not often the proper fix.