### PR TITLE
feat(diagnostics): warn on unused underscore captures

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,10 @@ options are:
     - `none`
     - `prefer_quoted`
     - `prefer_unquoted`
+- `warn_unused_underscore_captures`
+  - Whether to warn on `_`-prefixed captures which are not referenced by a
+    predicate or directive
+  - Default: `true`
 
 #### `valid_captures`
 

--- a/queries/query/diagnostics.scm
+++ b/queries/query/diagnostics.scm
@@ -2,8 +2,6 @@
 
 (MISSING) @missing
 
-(capture) @capture
-
 (escape_sequence) @escape
 
 (anonymous_node

--- a/schemas/config.json
+++ b/schemas/config.json
@@ -7,7 +7,8 @@
     "diagnostic_options": {
       "description": "Options related to diagnostics",
       "default": {
-        "string_argument_style": "none"
+        "string_argument_style": "none",
+        "warn_unused_underscore_captures": true
       },
       "allOf": [
         {
@@ -71,17 +72,20 @@
     "DiagnosticOptions": {
       "description": "Options related to diagnostics",
       "type": "object",
-      "required": [
-        "string_argument_style"
-      ],
       "properties": {
         "string_argument_style": {
           "description": "The style for predicate string arguments",
+          "default": "none",
           "allOf": [
             {
               "$ref": "#/definitions/StringArgumentStyle"
             }
           ]
+        },
+        "warn_unused_underscore_captures": {
+          "description": "Whether to warn on `_`-prefixed captures which are not referenced by a predicate or directive (default `true`)",
+          "default": true,
+          "type": "boolean"
         }
       }
     },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -139,11 +139,25 @@ fn prefixes_schema(gen_: &mut schemars::r#gen::SchemaGenerator) -> schemars::sch
 }
 
 /// Options related to diagnostics
-#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Default, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 pub struct DiagnosticOptions {
     /// The style for predicate string arguments
+    #[serde(default)]
     pub string_argument_style: StringArgumentStyle,
+    /// Whether to warn on `_`-prefixed captures which are not referenced by a predicate or directive
+    /// (default `true`)
+    #[serde(default = "default_true")]
+    pub warn_unused_underscore_captures: bool,
+}
+
+impl Default for DiagnosticOptions {
+    fn default() -> Self {
+        Self {
+            string_argument_style: Default::default(),
+            warn_unused_underscore_captures: true,
+        }
+    }
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Default, Clone)]


### PR DESCRIPTION
Can be disabled, enabled by default