### PR TITLE
Begin supporting `; inherits`

### DIFF
--- a/src/cli/check.rs
+++ b/src/cli/check.rs
@@ -9,9 +9,13 @@ use futures::future::join_all;
 use tower_lsp::lsp_types::Url;
 use ts_query_ls::Options;
 
-use crate::{LanguageData, handlers::did_open::init_language_data, util};
+use crate::{
+    LanguageData,
+    handlers::did_open::init_language_data,
+    util::{self, get_scm_files},
+};
 
-use super::{format::format_directories, get_scm_files, lint::lint_file};
+use super::{format::format_directories, lint::lint_file};
 
 static LANGUAGE_CACHE: LazyLock<DashMap<String, Arc<LanguageData>>> = LazyLock::new(DashMap::new);
 

--- a/src/cli/format.rs
+++ b/src/cli/format.rs
@@ -7,9 +7,7 @@ use std::{
 use futures::future::join_all;
 use ropey::Rope;
 
-use crate::{QUERY_LANGUAGE, handlers::formatting};
-
-use super::get_scm_files;
+use crate::{QUERY_LANGUAGE, handlers::formatting, util::get_scm_files};
 
 pub async fn format_directories(directories: &[PathBuf], check: bool) -> i32 {
     if directories.is_empty() {

--- a/src/cli/lint.rs
+++ b/src/cli/lint.rs
@@ -12,10 +12,8 @@ use ts_query_ls::Options;
 use crate::{
     DocumentData, LanguageData, QUERY_LANGUAGE,
     handlers::{code_action::diag_to_code_action, diagnostic::get_diagnostics},
-    util::{edit_rope, get_language_name},
+    util::{edit_rope, get_language_name, get_scm_files},
 };
-
-use super::get_scm_files;
 
 pub(super) async fn lint_file(
     path: &Path,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,23 +1,4 @@
-use std::path::PathBuf;
-
-use walkdir::WalkDir;
-
 pub(super) mod check;
 pub(super) mod format;
 pub(super) mod lint;
 pub(super) mod profile;
-
-pub(in crate::cli) fn get_scm_files(directories: &[PathBuf]) -> Vec<PathBuf> {
-    directories
-        .iter()
-        .flat_map(|directory| {
-            WalkDir::new(directory)
-                .into_iter()
-                .filter_map(|e| e.ok())
-                .filter(|e| {
-                    e.file_type().is_file() && e.path().extension().is_some_and(|ext| ext == "scm")
-                })
-                .map(|e| e.path().to_owned())
-        })
-        .collect()
-}

--- a/src/cli/profile.rs
+++ b/src/cli/profile.rs
@@ -11,9 +11,11 @@ use tower_lsp::lsp_types::Url;
 use tree_sitter::{Parser, Query, QueryCursor, StreamingIterator as _};
 use ts_query_ls::Options;
 
-use crate::{LanguageData, QUERY_LANGUAGE, handlers::did_open::init_language_data, util};
-
-use super::get_scm_files;
+use crate::{
+    LanguageData, QUERY_LANGUAGE,
+    handlers::did_open::init_language_data,
+    util::{self, get_scm_files},
+};
 
 static LANGUAGE_CACHE: LazyLock<DashMap<String, Arc<LanguageData>>> = LazyLock::new(DashMap::new);
 

--- a/src/handlers/goto_definition.rs
+++ b/src/handlers/goto_definition.rs
@@ -20,6 +20,9 @@ fn get_imported_module_under_cursor(
     tree: &Tree,
     position: &Position,
 ) -> Option<String> {
+    if position.line != 0 {
+        return None;
+    }
     let ts_point = position.to_ts_point(rope);
     let current_node = tree
         .root_node()

--- a/src/handlers/goto_definition.rs
+++ b/src/handlers/goto_definition.rs
@@ -1,17 +1,42 @@
+use ropey::Rope;
 use tower_lsp::{
     jsonrpc::Result,
-    lsp_types::{GotoDefinitionParams, GotoDefinitionResponse, Location},
+    lsp_types::{GotoDefinitionParams, GotoDefinitionResponse, Location, Position},
 };
 use tracing::{info, warn};
-use tree_sitter::{Parser, QueryCursor};
+use tree_sitter::{Parser, QueryCursor, Tree};
 
 use crate::{
     Backend, QUERY_LANGUAGE,
     util::{
-        CAPTURES_QUERY, NodeUtil, TextProviderRope, ToTsPoint, get_current_capture_node,
-        get_references,
+        CAPTURES_QUERY, INHERITS_REGEX, NodeUtil, TextProviderRope, ToTsPoint,
+        get_current_capture_node, get_file_uris, get_references, lsp_position_to_byte_offset,
+        uri_to_basename,
     },
 };
+
+fn get_imported_module_under_cursor(
+    rope: &Rope,
+    tree: &Tree,
+    position: &Position,
+) -> Option<String> {
+    let ts_point = position.to_ts_point(rope);
+    let current_node = tree
+        .root_node()
+        .descendant_for_point_range(ts_point, ts_point)
+        .filter(|node| node.kind() == "comment")?;
+    let node_text = current_node.text(rope);
+    let modules = INHERITS_REGEX.captures(&node_text).and_then(|c| c.get(1))?;
+    let cursor_offset = lsp_position_to_byte_offset(*position, rope).ok()?;
+    let mut comment_offset = current_node.start_byte() + modules.start();
+
+    modules.as_str().split(',').find_map(|module| {
+        let end = comment_offset + module.len();
+        let cursor_in_module = cursor_offset >= comment_offset && cursor_offset < end;
+        comment_offset = end + 1;
+        cursor_in_module.then(|| module.to_string())
+    })
+}
 
 pub async fn goto_definition(
     backend: &Backend,
@@ -26,6 +51,27 @@ pub async fn goto_definition(
     let rope = &doc.rope;
     let tree = &doc.tree;
     let cur_pos = params.text_document_position_params.position;
+
+    if let (Some(module), Some(query_name)) = (
+        get_imported_module_under_cursor(rope, tree, &cur_pos),
+        uri_to_basename(uri),
+    ) {
+        let uris = get_file_uris(backend, &module, &query_name).await;
+        if uris.is_empty() {
+            return Ok(None);
+        }
+
+        return Ok(Some(
+            uris.into_iter()
+                .map(|uri| Location {
+                    uri,
+                    range: Default::default(),
+                })
+                .collect::<Vec<_>>()
+                .into(),
+        ));
+    }
+
     let Some(current_node) = get_current_capture_node(tree.root_node(), cur_pos.to_ts_point(rope))
     else {
         return Ok(None);
@@ -65,7 +111,7 @@ mod test {
     use tower::{Service, ServiceExt};
     use tower_lsp::lsp_types::{
         GotoDefinitionParams, GotoDefinitionResponse, Location, PartialResultParams, Position,
-        Range, TextDocumentIdentifier, TextDocumentPositionParams, WorkDoneProgressParams,
+        Range, TextDocumentIdentifier, TextDocumentPositionParams, Url, WorkDoneProgressParams,
         request::GotoDefinition,
     };
 
@@ -80,23 +126,23 @@ mod test {
     #[case(
         &SIMPLE_FILE,
         Position { line: 0, character: 4 },
-        &[]
+        (TEST_URI.clone(), [].as_slice())
     )]
     #[case(
         &SIMPLE_FILE,
         Position { line: 0, character: 20 },
-        &[((0, 14), (0, 23))]
+        (TEST_URI.clone(), [((0, 14), (0, 23))].as_slice())
     )]
     #[case(
         &COMPLEX_FILE,
         Position { line: 12, character: 14 },
-        &[((8, 24), (8, 42)), ((9, 22), (9, 40))]
+        (TEST_URI.clone(), [((8, 24), (8, 42)), ((9, 22), (9, 40))].as_slice())
     )]
     #[tokio::test(flavor = "current_thread")]
     async fn goto_definition(
         #[case] input: &str,
         #[case] position: Position,
-        #[case] locations: &[Coordinate],
+        #[case] locations: (Url, &[Coordinate]),
     ) {
         // Arrange
         let mut service = initialize_server(
@@ -128,14 +174,15 @@ mod test {
             .unwrap();
 
         // Assert
-        let actual = if locations.is_empty() {
+        let actual = if locations.1.is_empty() {
             None
         } else {
             Some(GotoDefinitionResponse::Array(
                 locations
+                    .1
                     .iter()
                     .map(|r| Location {
-                        uri: TEST_URI.clone(),
+                        uri: locations.0.clone(),
                         range: Range {
                             start: Position {
                                 line: r.0.0,

--- a/src/handlers/initialize.rs
+++ b/src/handlers/initialize.rs
@@ -17,7 +17,7 @@ pub async fn initialize(backend: &Backend, params: InitializeParams) -> Result<I
         {
             ws_uris.push(root_uri);
         } else if let Some(ws_folders) = params.workspace_folders {
-            ws_uris.extend(ws_folders.iter().map(|folder| folder.uri.clone()));
+            ws_uris.extend(ws_folders.into_iter().map(|folder| folder.uri));
         }
     }
 

--- a/src/handlers/semantic_tokens.rs
+++ b/src/handlers/semantic_tokens.rs
@@ -21,7 +21,7 @@ static SEM_TOK_QUERY: LazyLock<Query> = LazyLock::new(|| {
         r#"(named_node (identifier) @ident)
 (missing_node (identifier) @ident)
 (program
-  . (comment)+ @comment)
+  . (comment) @comment)
 "#,
     )
     .unwrap()
@@ -122,6 +122,9 @@ async fn get_semantic_tokens(
                 }
                 // Highlight imported modules
                 "comment" => {
+                    if start_row != 0 {
+                        continue;
+                    }
                     let Some(pre_text) = INHERITS_REGEX.captures(&node_text).and_then(|c| c.get(1))
                     else {
                         continue;

--- a/src/main.rs
+++ b/src/main.rs
@@ -76,7 +76,11 @@ static SERVER_CAPABILITIES: LazyLock<ServerCapabilities> = LazyLock::new(|| Serv
     semantic_tokens_provider: Some(SemanticTokensServerCapabilities::SemanticTokensOptions(
         SemanticTokensOptions {
             legend: SemanticTokensLegend {
-                token_types: vec![SemanticTokenType::INTERFACE, SemanticTokenType::VARIABLE],
+                token_types: vec![
+                    SemanticTokenType::INTERFACE,
+                    SemanticTokenType::VARIABLE,
+                    SemanticTokenType::NAMESPACE,
+                ],
                 token_modifiers: vec![SemanticTokenModifier::DEFAULT_LIBRARY],
             },
             full: Some(SemanticTokensFullOptions::Bool(true)),

--- a/src/util.rs
+++ b/src/util.rs
@@ -23,6 +23,8 @@ static LANGUAGE_REGEX_2: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"tree-sitter-([^/]+)/queries/[^/]+\.scm$").unwrap());
 pub static CAPTURES_QUERY: LazyLock<Query> =
     LazyLock::new(|| Query::new(&QUERY_LANGUAGE, "(capture) @cap").unwrap());
+pub static INHERITS_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^;+\s*inherits: ([a-zA-Z0-9\-_,]+)").unwrap());
 
 /// Returns the starting byte of the character if the position is in the middle of a character.
 pub fn lsp_position_to_byte_offset(position: Position, rope: &Rope) -> Result<usize, ropey::Error> {


### PR DESCRIPTION
Adds support for:

- Semantic tokens for imported modules in `inherits` statements
- Goto definition for modules

TODO (separate PR(s)):

- Diagnostics (conceptually harder)
- Documentation (mention the modeline format, restrictions, etc.)
  - Do not make release until this happens
- Support `workspace/symbol` requests (#37)