### PR TITLE
refactor: configuration setting simplification

### DIFF
--- a/schemas/config.json
+++ b/schemas/config.json
@@ -18,10 +18,13 @@
     },
     "language_retrieval_patterns": {
       "description": "A list of patterns to aid the LSP in finding a language, given a file path. Patterns must have one capture group which represents the language name. Ordered from highest to lowest precedence.",
-      "default": [],
+      "default": [
+        "queries/([^/]+)/[^/]+\\.scm$",
+        "tree-sitter-([^/]+)/queries/[^/]+\\.scm$"
+      ],
       "type": "array",
       "items": {
-        "type": "string"
+        "$ref": "#/definitions/Regex"
       }
     },
     "parser_aliases": {
@@ -227,6 +230,11 @@
           ]
         }
       ]
+    },
+    "Regex": {
+      "description": "A regular expression string (compiled at deserialization time)",
+      "type": "string",
+      "format": "regex"
     },
     "StringArgumentStyle": {
       "oneOf": [

--- a/src/handlers/completion.rs
+++ b/src/handlers/completion.rs
@@ -549,6 +549,19 @@ mod test {
                 ..Default::default()
             },
             CompletionItem {
+                label: String::from("#not-eq?"),
+                kind: Some(CompletionItemKind::FUNCTION),
+                documentation: Some(tower_lsp::lsp_types::Documentation::MarkupContent(MarkupContent {
+                    kind: MarkupKind::Markdown,
+                    value: String::from("The inverse of `#eq?`, which is defined as follows:\n\nEquality check")
+                })),
+                insert_text_format: Some(InsertTextFormat::SNIPPET),
+                text_edit: Some(CompletionTextEdit::Edit(TextEdit {
+                    range: Range { start: Position { line: 0, character: 24 }, end: Position { line: 0, character: 25 } },
+                    new_text: String::from("#not-eq? ${1:@capture} ${2:text}") })),
+                ..Default::default()
+            },
+            CompletionItem {
                 label: String::from("#set!"),
                 kind: Some(CompletionItemKind::FUNCTION),
                 documentation:
@@ -630,7 +643,7 @@ mod test {
         .await;
 
         // Act
-        let completions = service
+        let actual_completions = service
             .ready()
             .await
             .unwrap()
@@ -652,16 +665,16 @@ mod test {
             .unwrap();
 
         // Assert
-        let actual_completions = if expected_completions.is_empty() {
+        let expected_completions = if expected_completions.is_empty() {
             None
         } else {
             Some(CompletionResponse::Array(expected_completions.to_vec()))
         };
         assert_eq!(
-            completions,
             Some(lsp_response_to_jsonrpc_response::<Completion>(
-                actual_completions
-            ))
+                expected_completions
+            )),
+            actual_completions,
         );
     }
 }

--- a/src/handlers/did_change_configuration.rs
+++ b/src/handlers/did_change_configuration.rs
@@ -18,6 +18,7 @@ pub async fn did_change_configuration(backend: &Backend, params: DidChangeConfig
 #[cfg(test)]
 mod test {
     use pretty_assertions::assert_eq;
+    use regex::Regex;
     use std::collections::BTreeMap;
     use tower::{Service, ServiceExt};
     use tower_lsp::lsp_types::{
@@ -81,7 +82,13 @@ mod test {
                     String::from("/my/directory/"),
                     String::from("/tmp/tree-sitter/parsers/"),
                 ],
-                language_retrieval_patterns: vec![String::from(r"\.ts\-([^/]+)\-parser\.wasm")],
+                language_retrieval_patterns: vec![
+                    Regex::new(r"\.ts\-([^/]+)\-parser\.wasm").unwrap().into(),
+                    Regex::new("queries/([^/]+)/[^/]+\\.scm$").unwrap().into(),
+                    Regex::new("tree-sitter-([^/]+)/queries/[^/]+\\.scm$",)
+                        .unwrap()
+                        .into(),
+                ],
                 ..Default::default()
             }
         );


### PR DESCRIPTION
Now language retrieval regexes are only compiled at deserialization time, rather than every time they need to be read. The same goes for the addition of the default regexes.

Now tests pass the initialization options in the initialization request, rather than setting the server field manually.