### PR TITLE
feat: workspace symbols support

### DIFF
--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -17,3 +17,4 @@ pub mod rename;
 pub mod selection_range;
 pub mod semantic_tokens;
 pub mod shutdown;
+pub mod workspace_symbol;

--- a/src/handlers/workspace_symbol.rs
+++ b/src/handlers/workspace_symbol.rs
@@ -1,0 +1,68 @@
+use std::fs;
+
+use ropey::Rope;
+use tower_lsp::{
+    jsonrpc::Result,
+    lsp_types::{Location, SymbolInformation, SymbolKind, Url, WorkspaceSymbolParams},
+};
+use tree_sitter::{Parser, QueryCursor, StreamingIterator};
+
+use crate::{
+    Backend, QUERY_LANGUAGE,
+    util::{CAPTURES_QUERY, NodeUtil, TextProviderRope, get_scm_files, is_subsequence},
+};
+
+pub async fn symbol(
+    backend: &Backend,
+    params: WorkspaceSymbolParams,
+) -> Result<Option<Vec<SymbolInformation>>> {
+    let mut symbols = Vec::new();
+    let query = params.query;
+
+    let dirs = backend
+        .workspace_uris
+        .read()
+        .as_deref()
+        .cloned()
+        .unwrap_or_default()
+        .into_iter()
+        .filter_map(|uri| uri.to_file_path().ok())
+        .collect::<Vec<_>>();
+
+    let mut parser = Parser::new();
+    parser
+        .set_language(&QUERY_LANGUAGE)
+        .expect("Language should load");
+
+    for path in get_scm_files(&dirs) {
+        if let (Ok(content), Ok(uri)) = (fs::read_to_string(&path), Url::from_file_path(path)) {
+            let rope = &Rope::from_str(&content);
+            let tree = parser.parse(&content, None).expect("Tree should exist");
+
+            let provider = &TextProviderRope(rope);
+            let mut cursor = QueryCursor::new();
+            let mut matches = cursor.matches(&CAPTURES_QUERY, tree.root_node(), provider);
+
+            while let Some(match_) = matches.next() {
+                for capture in match_.captures {
+                    let capture_node = capture.node;
+                    let node_text = capture_node.text(rope);
+
+                    if is_subsequence(&query, &node_text) {
+                        symbols.push(SymbolInformation {
+                            name: node_text,
+                            kind: SymbolKind::VARIABLE,
+                            location: Location::new(uri.clone(), capture_node.lsp_range(rope)),
+                            container_name: None,
+                            tags: None,
+                            #[allow(deprecated)]
+                            deprecated: None,
+                        });
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(Some(symbols))
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,7 +34,8 @@ use tower_lsp::{
         SemanticTokensFullOptions, SemanticTokensLegend, SemanticTokensOptions,
         SemanticTokensParams, SemanticTokensRangeParams, SemanticTokensRangeResult,
         SemanticTokensResult, SemanticTokensServerCapabilities, ServerCapabilities,
-        TextDocumentSyncCapability, TextDocumentSyncKind, TextEdit, Url, WorkspaceEdit,
+        SymbolInformation, TextDocumentSyncCapability, TextDocumentSyncKind, TextEdit, Url,
+        WorkspaceEdit, WorkspaceSymbolParams,
     },
 };
 use tree_sitter::{Language, Tree, wasmtime::Engine};
@@ -92,6 +93,7 @@ static SERVER_CAPABILITIES: LazyLock<ServerCapabilities> = LazyLock::new(|| Serv
     hover_provider: Some(HoverProviderCapability::Simple(true)),
     document_symbol_provider: Some(OneOf::Left(true)),
     selection_range_provider: Some(SelectionRangeProviderCapability::Simple(true)),
+    workspace_symbol_provider: Some(OneOf::Left(true)),
     ..Default::default()
 });
 static ENGINE: LazyLock<Engine> = LazyLock::new(Engine::default);
@@ -222,6 +224,13 @@ impl LanguageServer for Backend {
         params: DocumentSymbolParams,
     ) -> Result<Option<DocumentSymbolResponse>> {
         document_symbol::document_symbol(self, params).await
+    }
+
+    async fn symbol(
+        &self,
+        params: WorkspaceSymbolParams,
+    ) -> Result<Option<Vec<SymbolInformation>>> {
+        workspace_symbol::symbol(self, params).await
     }
 
     async fn diagnostic(

--- a/src/util.rs
+++ b/src/util.rs
@@ -454,3 +454,22 @@ pub async fn get_imported_uris(
 
     uris
 }
+
+/// Check if a string is a subsequence of another string; in order words, it is contained in the
+/// other string with possible gaps between characters.
+pub fn is_subsequence(sub: &str, main: &str) -> bool {
+    let mut sub_iter = sub.chars().peekable();
+    let mut main_iter = main.chars();
+
+    while let Some(&sub_char) = sub_iter.peek() {
+        match main_iter.next() {
+            Some(main_char) if main_char == sub_char => {
+                sub_iter.next();
+            }
+            None => return false,
+            _ => {}
+        }
+    }
+
+    true
+}


### PR DESCRIPTION
Closes #37

Unfortunately, tower-lsp only supports the deprecated `workspace/symbols` signature right now.

CC @clason would you mind taking a look and seeing if this is what you had in mind? I wasn't sure how to make use of `; inherits` here to specify file dependencies in the symbols