### PR TITLE
refactor: store workspace URIs as PathBufs rather than Urls

### DIFF
--- a/src/cli/check.rs
+++ b/src/cli/check.rs
@@ -39,13 +39,10 @@ pub async fn check_directories(
     } else {
         directories
     };
-    let workspace = Url::from_file_path(
-        workspace
-            .unwrap_or(env::current_dir().expect("Failed to get current directory"))
-            .canonicalize()
-            .expect("Workspace path should be valid"),
-    )
-    .expect("Workspace path should be absolute");
+    let workspace = workspace
+        .unwrap_or(env::current_dir().expect("Failed to get current directory"))
+        .canonicalize()
+        .expect("Workspace path should be valid");
     let workspace = Arc::new(workspace);
     let scm_files = get_scm_files(directories);
     let tasks = scm_files.into_iter().filter_map(|path| {

--- a/src/handlers/did_open.rs
+++ b/src/handlers/did_open.rs
@@ -1,6 +1,7 @@
 use std::{
     collections::{BTreeSet, HashMap, HashSet},
     fs,
+    path::PathBuf,
 };
 
 use dashmap::DashMap;
@@ -136,7 +137,7 @@ pub fn init_language_data(lang: Language, name: String) -> LanguageData {
 
 pub async fn populate_import_documents(
     document_map: &DashMap<Url, DocumentData>,
-    workspace_uris: &[Url],
+    workspace_dirs: &[PathBuf],
     options: &Options,
     imported_uris: &Vec<(u32, u32, Option<Url>)>,
 ) {
@@ -154,7 +155,7 @@ pub async fn populate_import_documents(
                 .expect("Error loading Query grammar");
             let tree = parser.parse(&contents, None).unwrap();
             let nested_imported_uris =
-                get_imported_uris(workspace_uris, options, uri, &rope, &tree).await;
+                get_imported_uris(workspace_dirs, options, uri, &rope, &tree).await;
             document_map.insert(
                 uri.clone(),
                 DocumentData {
@@ -167,7 +168,7 @@ pub async fn populate_import_documents(
             );
             Box::pin(populate_import_documents(
                 document_map,
-                workspace_uris,
+                workspace_dirs,
                 options,
                 &nested_imported_uris,
             ))

--- a/src/handlers/initialize.rs
+++ b/src/handlers/initialize.rs
@@ -12,10 +12,17 @@ pub async fn initialize(backend: &Backend, params: InitializeParams) -> Result<I
     if let Ok(mut ws_uris) = backend.workspace_uris.write() {
         #[allow(deprecated)]
         if let Some(ws_folders) = params.workspace_folders {
-            ws_uris.extend(ws_folders.into_iter().map(|folder| folder.uri));
-        } else if let Some(root_uri) = params.root_uri.or(params
-            .root_path
-            .and_then(|p| Url::from_str(p.as_str()).ok()))
+            ws_uris.extend(
+                ws_folders
+                    .into_iter()
+                    .filter_map(|folder| folder.uri.to_file_path().ok()),
+            );
+        } else if let Some(root_uri) = params
+            .root_uri
+            .or(params
+                .root_path
+                .and_then(|p| Url::from_str(p.as_str()).ok()))
+            .and_then(|uri| uri.to_file_path().ok())
         {
             ws_uris.push(root_uri);
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -136,7 +136,7 @@ struct Backend {
     document_map: DashMap<Url, DocumentData>,
     language_map: DashMap<String, Arc<LanguageData>>,
     options: Arc<tokio::sync::RwLock<Options>>,
-    workspace_uris: Arc<RwLock<Vec<Url>>>,
+    workspace_uris: Arc<RwLock<Vec<PathBuf>>>,
 }
 
 #[tower_lsp::async_trait]


### PR DESCRIPTION
This aligns the types to rust's own path types, rather than the LSP-specific URI type. This simplifies a lot of the code, which performed a lot of redundant URI to path conversion.