### PR TITLE
feat: respect gitignore, hidden files when searching workspace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -162,6 +162,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 
 [[package]]
+name = "bstr"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234113d19d0d7d613b40e86fb654acf958910802bcceab913a4f9e7cda03b1a4"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -357,6 +367,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -589,6 +618,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
+name = "globset"
+version = "0.4.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54a1028dfc5f5df5da8a56a73e6c153c9a9708ec57232470703592a3f18e49f5"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -730,6 +772,22 @@ checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "ignore"
+version = "0.4.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d89fd380afde86567dfba715db065673989d6253f42b88179abd3eae47bda4b"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata",
+ "same-file",
+ "walkdir",
+ "winapi-util",
 ]
 
 [[package]]
@@ -1648,6 +1706,7 @@ dependencies = [
  "dashmap 6.1.0",
  "dissimilar",
  "futures",
+ "ignore",
  "libloading",
  "pretty_assertions",
  "regex",
@@ -1664,7 +1723,6 @@ dependencies = [
  "tracing-subscriber",
  "tree-sitter",
  "tree-sitter-query",
- "walkdir",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ clap = { version = "4.5.31", features = ["derive"] }
 dashmap = "6.1.0"
 dissimilar = "1.0.9"
 futures = "0.3.31"
+ignore = "0.4.23"
 libloading = "0.8.5"
 regex = "1.11.0"
 ropey = "1.6.1"
@@ -39,7 +40,6 @@ tracing = "0.1.41"
 tracing-subscriber = "0.3.18"
 tree-sitter = { version = "0.25.4", features = ["std", "wasm"] }
 tree-sitter-query = { git = "https://github.com/tree-sitter-grammars/tree-sitter-query", rev = "2b3669919b22f1a6e5bfcf3753caaa63fd14e8ec" }
-walkdir = "2.5.0"
 
 [build-dependencies]
 cc = "1.1.30"

--- a/README.md
+++ b/README.md
@@ -240,6 +240,8 @@ vim.api.nvim_create_autocmd('FileType', {
     `language_retrieval_pattern`. Note that imported files will match the query
     type of the original (e.g. `; inherits: foo`) inside `bar/highlights.scm`
     will retrieve `foo/highlights.scm`, and not e.g. `foo/folds.scm`.
+  - Query files will not be searched within hidden directories or `gitignore`d
+    locations.
 - Support for hover, selection range, document symbols, semantic tokens, code
   actions, and document highlight
 


### PR DESCRIPTION
Internally, this swaps walkdir for the heavier, more feature-rich and parallelizable ignore crate when searching for `.scm` files.