### PR TITLE
feat(completion): support for `inherits:` and module names

### DIFF
--- a/queries/test_workspace/queries/cpp/test.scm
+++ b/queries/test_workspace/queries/cpp/test.scm
@@ -1,0 +1,1 @@
+; test query

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -5,6 +5,8 @@ pub mod helpers {
 
     use std::{
         collections::{BTreeSet, HashMap, HashSet},
+        path::PathBuf,
+        str::FromStr,
         sync::{Arc, LazyLock},
     };
     use tower::{Service, ServiceExt};
@@ -115,7 +117,16 @@ pub mod helpers {
                     )
                 },
             )),
-            workspace_uris: Default::default(),
+            workspace_uris: Arc::new(
+                vec![
+                    PathBuf::from_str(concat!(
+                        env!("CARGO_MANIFEST_DIR"),
+                        "/queries/test_workspace/"
+                    ))
+                    .unwrap(),
+                ]
+                .into(),
+            ),
             options: arced_options,
         })
         .finish();


### PR DESCRIPTION
Also adds a test workspace folder which can be used in other places for better testing with workspace-related features and `; inherits`