### PR TITLE
fix: wrong type for workspace URIs when finding symbols

### DIFF
--- a/src/handlers/workspace_symbol.rs
+++ b/src/handlers/workspace_symbol.rs
@@ -24,10 +24,7 @@ pub async fn symbol(
         .read()
         .as_deref()
         .cloned()
-        .unwrap_or_default()
-        .into_iter()
-        .filter_map(|uri| uri.to_file_path().ok())
-        .collect::<Vec<_>>();
+        .unwrap_or_default();
 
     let mut parser = Parser::new();
     parser


### PR DESCRIPTION
I guess I should remember to rebase all my branches before merging...