### PR TITLE
feat(cli): print diff when using format --check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,9 +61,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
 
 [[package]]
 name = "anstyle-parse"
@@ -80,7 +80,7 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -91,7 +91,7 @@ checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
 dependencies = [
  "anstyle",
  "once_cell",
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -428,6 +428,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
+name = "diffy"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b545b8c50194bdd008283985ab0b31dba153cfd5b3066a92770634fbc0d7d291"
+dependencies = [
+ "nu-ansi-term 0.50.1",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -481,7 +490,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -941,6 +950,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.50.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4a28e057d01f97e61255210fcff094d74ed0466038633e95017f5beb68e4399"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "object"
 version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1229,7 +1247,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1659,7 +1677,7 @@ version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
 dependencies = [
- "nu-ansi-term",
+ "nu-ansi-term 0.46.0",
  "sharded-slab",
  "smallvec",
  "thread_local",
@@ -1701,9 +1719,11 @@ dependencies = [
 name = "ts_query_ls"
 version = "3.4.1"
 dependencies = [
+ "anstyle",
  "cc",
  "clap",
  "dashmap 6.1.0",
+ "diffy",
  "dissimilar",
  "futures",
  "ignore",
@@ -1857,7 +1877,7 @@ dependencies = [
  "wasmtime-slab",
  "wasmtime-versioned-export-macros",
  "wasmtime-winch",
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1973,7 +1993,7 @@ dependencies = [
  "rustix",
  "wasmtime-asm-macros",
  "wasmtime-versioned-export-macros",
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1985,7 +2005,7 @@ dependencies = [
  "anyhow",
  "cfg-if",
  "libc",
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2065,7 +2085,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2090,6 +2110,15 @@ dependencies = [
  "wasmparser",
  "wasmtime-cranelift",
  "wasmtime-environ",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,8 +22,10 @@ path = "src/lib.rs"
 schema = ["schemars"]
 
 [dependencies]
+anstyle = "1.0.11"
 clap = { version = "4.5.31", features = ["derive"] }
 dashmap = "6.1.0"
+diffy = "0.4.2"
 dissimilar = "1.0.9"
 futures = "0.3.31"
 ignore = "0.4.23"

--- a/src/cli/format.rs
+++ b/src/cli/format.rs
@@ -44,6 +44,11 @@ pub async fn format_directories(directories: &[PathBuf], check: bool) -> i32 {
             let tree = parser.parse(contents.as_str(), None).unwrap();
             let rope = Rope::from(contents.as_str());
             let Some(formatted) = formatting::format_document(&rope, &tree.root_node()) else {
+                exit_code.store(1, std::sync::atomic::Ordering::Relaxed);
+                eprintln!(
+                    "Unable to format -- Syntax error detected for {:?}",
+                    path.canonicalize().unwrap()
+                );
                 return;
             };
             if check {

--- a/src/cli/format.rs
+++ b/src/cli/format.rs
@@ -46,7 +46,7 @@ pub async fn format_directories(directories: &[PathBuf], check: bool) -> i32 {
             let Some(formatted) = formatting::format_document(&rope, &tree.root_node()) else {
                 exit_code.store(1, std::sync::atomic::Ordering::Relaxed);
                 eprintln!(
-                    "Unable to format -- Syntax error detected for {:?}",
+                    "No formatting performed -- invalid syntax detected at {:?}",
                     path.canonicalize().unwrap()
                 );
                 return;
@@ -71,7 +71,7 @@ pub async fn format_directories(directories: &[PathBuf], check: bool) -> i32 {
                             eprintln!("{line}");
                         }
                     }
-                    println!();
+                    eprintln!();
                 }
             } else if fs::write(&path, formatted).is_err() {
                 exit_code.store(1, std::sync::atomic::Ordering::Relaxed);


### PR DESCRIPTION
I noticed the cli tool silently fails when invoking `format` on a malformed file. (I was testing out the coloring logic by adding a line to a .`scm` file that started with `@@`.) Happy to revert if this is the intended behavior.

Edit: Ah, I see this is already covered in a test. I could revert the second commit and keep the existing behavior, or change the test to expect a non-empty output (and maybe a different non-zero exit code?). Which way would you like to go forward? 🙂

- Closes #98 