### PR TITLE
test: overhaul initialization logic

### DIFF
--- a/queries/test_workspace/queries/cpp/test.scm
+++ b/queries/test_workspace/queries/cpp/test.scm
@@ -1,1 +1,3 @@
 ; test query
+
+(squid)

--- a/src/handlers/code_action.rs
+++ b/src/handlers/code_action.rs
@@ -345,18 +345,7 @@ mod test {
         #[case] expected_code_actions: &[CodeActionOrCommand],
     ) {
         // Arrange
-        let mut service = initialize_server(
-            &[(
-                TEST_URI.clone(),
-                source,
-                Vec::new(),
-                Vec::new(),
-                Vec::new(),
-                Vec::new(),
-            )],
-            &options,
-        )
-        .await;
+        let mut service = initialize_server(&[(TEST_URI.clone(), source)], &[], &options).await;
 
         // Act
         let code_actions = service

--- a/src/handlers/completion.rs
+++ b/src/handlers/completion.rs
@@ -750,13 +750,12 @@ the `inherits:` keyword, and there must be no spaces in-between module names.
     ) {
         // Arrange
         let mut service = initialize_server(
+            &[(TEST_URI.clone(), source)],
             &[(
-                TEST_URI.clone(),
-                source,
+                String::from("js"),
                 symbols.to_vec(),
                 fields.to_vec(),
                 supertypes.to_vec(),
-                Vec::new(),
             )],
             options,
         )

--- a/src/handlers/did_change.rs
+++ b/src/handlers/did_change.rs
@@ -123,18 +123,8 @@ mod test {
         #[case] edits: &[TestEdit],
     ) {
         // Arrange
-        let mut service = initialize_server(
-            &[(
-                TEST_URI.clone(),
-                original,
-                Vec::new(),
-                Vec::new(),
-                Vec::new(),
-                Vec::new(),
-            )],
-            &Default::default(),
-        )
-        .await;
+        let mut service =
+            initialize_server(&[(TEST_URI.clone(), original)], &[], &Default::default()).await;
 
         // Act
         service

--- a/src/handlers/did_change_configuration.rs
+++ b/src/handlers/did_change_configuration.rs
@@ -33,7 +33,7 @@ mod test {
     #[tokio::test(flavor = "current_thread")]
     async fn server_did_change_configuration() {
         // Arrange
-        let mut service = initialize_server(&[], &Default::default()).await;
+        let mut service = initialize_server(&[], &[], &Default::default()).await;
 
         // Act
         service

--- a/src/handlers/did_open.rs
+++ b/src/handlers/did_open.rs
@@ -185,7 +185,7 @@ mod test {
     #[tokio::test(flavor = "current_thread")]
     async fn server_did_open_document() {
         // Arrange
-        let mut service = initialize_server(&[], &Default::default()).await;
+        let mut service = initialize_server(&[], &[], &Default::default()).await;
         let source = r#""[" @cap"#;
 
         // Act

--- a/src/handlers/document_highlight.rs
+++ b/src/handlers/document_highlight.rs
@@ -192,18 +192,8 @@ expression: (boolean) @boolean",
         #[case] highlights: &[Highlight],
     ) {
         // Arrange
-        let mut service = initialize_server(
-            &[(
-                TEST_URI.clone(),
-                input,
-                Vec::new(),
-                Vec::new(),
-                Vec::new(),
-                Vec::new(),
-            )],
-            &Default::default(),
-        )
-        .await;
+        let mut service =
+            initialize_server(&[(TEST_URI.clone(), input)], &[], &Default::default()).await;
 
         // Act
         let refs = service

--- a/src/handlers/document_symbol.rs
+++ b/src/handlers/document_symbol.rs
@@ -140,18 +140,8 @@ mod test {
     #[tokio::test(flavor = "current_thread")]
     async fn document_symbol(#[case] source: &str, #[case] symbols: Vec<DocSymbol>) {
         // Arrange
-        let mut service = initialize_server(
-            &[(
-                TEST_URI.clone(),
-                source,
-                Vec::new(),
-                Vec::new(),
-                Vec::new(),
-                Vec::new(),
-            )],
-            &Default::default(),
-        )
-        .await;
+        let mut service =
+            initialize_server(&[(TEST_URI.clone(), source)], &[], &Default::default()).await;
 
         // Act
         let tokens = service

--- a/src/handlers/formatting.rs
+++ b/src/handlers/formatting.rs
@@ -362,18 +362,8 @@ mod test {
     #[tokio::test(flavor = "current_thread")]
     async fn server_formatting(#[case] before: &str, #[case] after: &str) {
         // Arrange
-        let mut service = initialize_server(
-            &[(
-                TEST_URI.clone(),
-                before,
-                Vec::new(),
-                Vec::new(),
-                Vec::new(),
-                Vec::new(),
-            )],
-            &Default::default(),
-        )
-        .await;
+        let mut service =
+            initialize_server(&[(TEST_URI.clone(), before)], &[], &Default::default()).await;
 
         // Act
         let delta = service

--- a/src/handlers/goto_definition.rs
+++ b/src/handlers/goto_definition.rs
@@ -150,18 +150,8 @@ mod test {
         #[case] locations: (Url, &[Coordinate]),
     ) {
         // Arrange
-        let mut service = initialize_server(
-            &[(
-                TEST_URI.clone(),
-                input,
-                Vec::new(),
-                Vec::new(),
-                Vec::new(),
-                Vec::new(),
-            )],
-            &Default::default(),
-        )
-        .await;
+        let mut service =
+            initialize_server(&[(TEST_URI.clone(), input)], &[], &Default::default()).await;
 
         // Act
         let refs = service

--- a/src/handlers/hover.rs
+++ b/src/handlers/hover.rs
@@ -397,14 +397,8 @@ An error node", BTreeMap::from([(String::from("error"), String::from("An error n
     ) {
         // Arrange
         let mut service = initialize_server(
-            &[(
-                TEST_URI.clone(),
-                source,
-                Vec::new(),
-                Vec::new(),
-                supertypes,
-                Vec::new(),
-            )],
+            &[(TEST_URI.clone(), source)],
+            &[(String::from("js"), Vec::new(), Vec::new(), supertypes)],
             &Options {
                 valid_captures: HashMap::from([(String::from("test"), captures)]),
                 valid_predicates: BTreeMap::from([(

--- a/src/handlers/references.rs
+++ b/src/handlers/references.rs
@@ -125,18 +125,8 @@ function: (identifier) @function)",
         #[case] ranges: &[Coordinate],
     ) {
         // Arrange
-        let mut service = initialize_server(
-            &[(
-                TEST_URI.clone(),
-                input,
-                Vec::new(),
-                Vec::new(),
-                Vec::new(),
-                Vec::new(),
-            )],
-            &Default::default(),
-        )
-        .await;
+        let mut service =
+            initialize_server(&[(TEST_URI.clone(), input)], &[], &Default::default()).await;
 
         // Act
         let refs = service

--- a/src/handlers/rename.rs
+++ b/src/handlers/rename.rs
@@ -131,18 +131,8 @@ mod test {
         #[case] new_name: &str,
     ) {
         // Arrange
-        let mut service = initialize_server(
-            &[(
-                TEST_URI.clone(),
-                original,
-                Vec::new(),
-                Vec::new(),
-                Vec::new(),
-                Vec::new(),
-            )],
-            &Default::default(),
-        )
-        .await;
+        let mut service =
+            initialize_server(&[(TEST_URI.clone(), original)], &[], &Default::default()).await;
 
         // Act
         let rename_edits = service

--- a/src/handlers/selection_range.rs
+++ b/src/handlers/selection_range.rs
@@ -107,14 +107,8 @@ mod test {
     ) {
         // Arrange
         let mut service = initialize_server(
-            &[(
-                TEST_URI.clone(),
-                document_text,
-                Vec::new(),
-                Vec::new(),
-                Vec::new(),
-                Vec::new(),
-            )],
+            &[(TEST_URI.clone(), document_text)],
+            &[],
             &Default::default(),
         )
         .await;

--- a/src/handlers/semantic_tokens.rs
+++ b/src/handlers/semantic_tokens.rs
@@ -224,13 +224,12 @@ mod test {
 (foo)
         ";
         let mut service = initialize_server(
+            &[(TEST_URI.clone(), source)],
             &[(
-                TEST_URI.clone(),
-                source,
+                String::from("js"),
                 Vec::new(),
                 Vec::new(),
                 vec!["supertype"],
-                Vec::new(),
             )],
             &Default::default(),
         )

--- a/src/main.rs
+++ b/src/main.rs
@@ -122,7 +122,7 @@ struct DocumentData {
     imported_uris: Vec<(u32, u32, Option<Url>)>,
 }
 
-#[derive(Default, Debug)]
+#[derive(Clone, Default, Debug)]
 struct LanguageData {
     name: String,
     symbols_set: HashSet<SymbolInfo>,


### PR DESCRIPTION
This is a large refactor that separates the document population logic from the language population logic. This allows us to craft much more granular tests, such as ones that check for diagnostics when no languages are found. It also paves the way to using real language objects in tests, to provide full end-to-end coverage. Additionally, it allows tests to be fully workspace-aware, allowing coverage for workspace methods (e.g. workspace symbols), and for diagnostics which require importing files from the workspace.

It also removes the custom test document population logic with actual calls to `textDocument/didOpen`, giving full coverage for that notification.