### PR TITLE
test: use query language object in mock tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,9 +359,6 @@ ts_query_ls profile --help
 - [x] Add tests for all* functionality
 - [x] Support for importing query modules via the `; inherits: foo` modeline
 
-> *All handlers are tested, but core functionality like language loading will be
-> more complicated, and does not yet have test coverage.
-
 ### Packaging
 
 - [ ] [`homebrew`](https://github.com/Homebrew/homebrew-core)

--- a/queries/test_workspace/queries/other/test.scm
+++ b/queries/test_workspace/queries/other/test.scm
@@ -1,0 +1,3 @@
+; should match "query" language nodes
+
+(definition)

--- a/src/cli/profile.rs
+++ b/src/cli/profile.rs
@@ -50,7 +50,7 @@ pub async fn profile_directories(directories: &[PathBuf], config: String, per_fi
             );
             return None;
         };
-        let lang = lang_data.language.clone().unwrap();
+        let lang = lang_data.language.clone();
         let Ok(source) = fs::read_to_string(&path) else {
             eprintln!("Failed to read {:?}", path.canonicalize().unwrap());
             return None;

--- a/src/handlers/code_action.rs
+++ b/src/handlers/code_action.rs
@@ -345,7 +345,7 @@ mod test {
         #[case] expected_code_actions: &[CodeActionOrCommand],
     ) {
         // Arrange
-        let mut service = initialize_server(&[(TEST_URI.clone(), source)], &[], &options).await;
+        let mut service = initialize_server(&[(TEST_URI.clone(), source)], &options).await;
 
         // Act
         let code_actions = service

--- a/src/handlers/did_change.rs
+++ b/src/handlers/did_change.rs
@@ -124,7 +124,7 @@ mod test {
     ) {
         // Arrange
         let mut service =
-            initialize_server(&[(TEST_URI.clone(), original)], &[], &Default::default()).await;
+            initialize_server(&[(TEST_URI.clone(), original)], &Default::default()).await;
 
         // Act
         service

--- a/src/handlers/did_change_configuration.rs
+++ b/src/handlers/did_change_configuration.rs
@@ -33,7 +33,7 @@ mod test {
     #[tokio::test(flavor = "current_thread")]
     async fn server_did_change_configuration() {
         // Arrange
-        let mut service = initialize_server(&[], &[], &Default::default()).await;
+        let mut service = initialize_server(&[], &Default::default()).await;
 
         // Act
         service

--- a/src/handlers/document_highlight.rs
+++ b/src/handlers/document_highlight.rs
@@ -193,7 +193,7 @@ expression: (boolean) @boolean",
     ) {
         // Arrange
         let mut service =
-            initialize_server(&[(TEST_URI.clone(), input)], &[], &Default::default()).await;
+            initialize_server(&[(TEST_URI.clone(), input)], &Default::default()).await;
 
         // Act
         let refs = service

--- a/src/handlers/document_symbol.rs
+++ b/src/handlers/document_symbol.rs
@@ -141,7 +141,7 @@ mod test {
     async fn document_symbol(#[case] source: &str, #[case] symbols: Vec<DocSymbol>) {
         // Arrange
         let mut service =
-            initialize_server(&[(TEST_URI.clone(), source)], &[], &Default::default()).await;
+            initialize_server(&[(TEST_URI.clone(), source)], &Default::default()).await;
 
         // Act
         let tokens = service

--- a/src/handlers/formatting.rs
+++ b/src/handlers/formatting.rs
@@ -363,7 +363,7 @@ mod test {
     async fn server_formatting(#[case] before: &str, #[case] after: &str) {
         // Arrange
         let mut service =
-            initialize_server(&[(TEST_URI.clone(), before)], &[], &Default::default()).await;
+            initialize_server(&[(TEST_URI.clone(), before)], &Default::default()).await;
 
         // Act
         let delta = service

--- a/src/handlers/goto_definition.rs
+++ b/src/handlers/goto_definition.rs
@@ -151,7 +151,7 @@ mod test {
     ) {
         // Arrange
         let mut service =
-            initialize_server(&[(TEST_URI.clone(), input)], &[], &Default::default()).await;
+            initialize_server(&[(TEST_URI.clone(), input)], &Default::default()).await;
 
         // Act
         let refs = service

--- a/src/handlers/hover.rs
+++ b/src/handlers/hover.rs
@@ -211,15 +211,15 @@ mod test {
     };
 
     use crate::test_helpers::helpers::{
-        TEST_URI, initialize_server, lsp_request_to_jsonrpc_request,
+        QUERY_TEST_URI, initialize_server, lsp_request_to_jsonrpc_request,
         lsp_response_to_jsonrpc_response,
     };
 
-    const SOURCE: &str = r"(ERROR) @error (supertype) @node
+    const SOURCE: &str = r"(ERROR) @error (definition) @node
 
-(supertype/test) @node
+(definition/test) @node
 
-(MISSING supertype) @node
+(MISSING definition) @node
 
 (_) @any
 _ @any
@@ -238,126 +238,141 @@ _ @any
 ";
 
     #[rstest]
-    #[case(SOURCE, vec!["supertype"], Position { line: 0, character: 2 }, Range::new(
+    #[case(SOURCE, Position { line: 0, character: 2 }, Range::new(
         Position { line: 0, character: 1 },
         Position { line: 0, character: 6 } ),
     include_str!(concat!(
         env!("CARGO_MANIFEST_DIR"),
         "/docs/error.md"
     )), Default::default())]
-    #[case(SOURCE, vec!["supertype"], Position { line: 4, character: 4 }, Range::new(
+    #[case(SOURCE, Position { line: 4, character: 4 }, Range::new(
         Position { line: 4, character: 1 },
         Position { line: 4, character: 8 } ),
     include_str!(concat!(
         env!("CARGO_MANIFEST_DIR"),
         "/docs/missing.md"
     )), Default::default())]
-    #[case(SOURCE, vec!["supertype"], Position { line: 6, character: 1 }, Range::new(
+    #[case(SOURCE, Position { line: 6, character: 1 }, Range::new(
         Position { line: 6, character: 1 },
         Position { line: 6, character: 2 } ),
     include_str!(concat!(
         env!("CARGO_MANIFEST_DIR"),
         "/docs/wildcard.md"
     )), Default::default())]
-    #[case(SOURCE, vec!["supertype"], Position { line: 7, character: 0 }, Range::new(
+    #[case(SOURCE, Position { line: 7, character: 0 }, Range::new(
         Position { line: 7, character: 0 },
         Position { line: 7, character: 1 } ),
     include_str!(concat!(
         env!("CARGO_MANIFEST_DIR"),
         "/docs/wildcard.md"
     )), Default::default())]
-    #[case(SOURCE, vec!["supertype"], Position { line: 0, character: 17 }, Range::new(
+    #[case(SOURCE, Position { line: 0, character: 17 }, Range::new(
         Position { line: 0, character: 16 },
-        Position { line: 0, character: 25 } ),
-    r"Subtypes of `(supertype)`:
+        Position { line: 0, character: 26 } ),
+    r"Subtypes of `(definition)`:
 
 ```query
-(test)
-(test2)
+(anonymous_node)
+(field_definition)
+(grouping)
+(list)
+(missing_node)
+(named_node)
+(predicate)
 ```", Default::default())]
-    #[case(SOURCE, vec!["supertype"], Position { line: 2, character: 4 }, Range::new(
+    #[case(SOURCE, Position { line: 2, character: 4 }, Range::new(
         Position { line: 2, character: 1 },
-        Position { line: 2, character: 10 } ),
-    r"Subtypes of `(supertype)`:
+        Position { line: 2, character: 11 } ),
+    r"Subtypes of `(definition)`:
 
 ```query
-(test)
-(test2)
+(anonymous_node)
+(field_definition)
+(grouping)
+(list)
+(missing_node)
+(named_node)
+(predicate)
 ```", Default::default())]
-    #[case(SOURCE, vec!["supertype"], Position { line: 4, character: 10 }, Range::new(
+    #[case(SOURCE, Position { line: 4, character: 10 }, Range::new(
         Position { line: 4, character: 9 },
-        Position { line: 4, character: 18 } ),
-    r"Subtypes of `(supertype)`:
+        Position { line: 4, character: 19 } ),
+    r"Subtypes of `(definition)`:
 
 ```query
-(test)
-(test2)
+(anonymous_node)
+(field_definition)
+(grouping)
+(list)
+(missing_node)
+(named_node)
+(predicate)
 ```", Default::default())]
-    #[case(SOURCE, vec!["supertype"], Position { line: 0, character: 10 }, Range::new(
+    #[case(SOURCE, Position { line: 0, character: 10 }, Range::new(
         Position { line: 0, character: 8 },
         Position { line: 0, character: 14 } ),
     r"## `@error`
 
 An error node", BTreeMap::from([(String::from("error"), String::from("An error node"))]))]
-    #[case(SOURCE, vec![], Position { line: 9, character: 10 }, Range::new(
+    #[case(SOURCE, Position { line: 9, character: 10 }, Range::new(
         Position { line: 9, character: 10 },
         Position { line: 9, character: 11 } ),
     include_str!(concat!(
         env!("CARGO_MANIFEST_DIR"),
         "/docs/anchor.md"
     )), BTreeMap::from([(String::from("error"), String::from("An error node"))]))]
-    #[case(SOURCE, vec![], Position { line: 9, character: 24 }, Range::new(
+    #[case(SOURCE, Position { line: 9, character: 24 }, Range::new(
         Position { line: 9, character: 24 },
         Position { line: 9, character: 25 } ),
     include_str!(concat!(
         env!("CARGO_MANIFEST_DIR"),
         "/docs/quantifier.md"
     )), BTreeMap::from([(String::from("error"), String::from("An error node"))]))]
-    #[case(SOURCE, vec![], Position { line: 11, character: 24 }, Range::new(
+    #[case(SOURCE, Position { line: 11, character: 24 }, Range::new(
         Position { line: 11, character: 24 },
         Position { line: 11, character: 25 } ),
     include_str!(concat!(
         env!("CARGO_MANIFEST_DIR"),
         "/docs/quantifier.md"
     )), BTreeMap::from([(String::from("error"), String::from("An error node"))]))]
-    #[case(SOURCE, vec![], Position { line: 11, character: 22 }, Range::new(
+    #[case(SOURCE, Position { line: 11, character: 22 }, Range::new(
         Position { line: 11, character: 22 },
         Position { line: 11, character: 23 } ),
     include_str!(concat!(
         env!("CARGO_MANIFEST_DIR"),
         "/docs/quantifier.md"
     )), BTreeMap::from([(String::from("error"), String::from("An error node"))]))]
-    #[case(SOURCE, vec![], Position { line: 13, character: 0 }, Range::new(
+    #[case(SOURCE, Position { line: 13, character: 0 }, Range::new(
         Position { line: 13, character: 0 },
         Position { line: 13, character: 1 } ),
     include_str!(concat!(
         env!("CARGO_MANIFEST_DIR"),
         "/docs/alternation.md"
     )), BTreeMap::from([(String::from("error"), String::from("An error node"))]))]
-    #[case(SOURCE, vec![], Position { line: 13, character: 21 }, Range::new(
+    #[case(SOURCE, Position { line: 13, character: 21 }, Range::new(
         Position { line: 13, character: 21 },
         Position { line: 13, character: 22 } ),
     include_str!(concat!(
         env!("CARGO_MANIFEST_DIR"),
         "/docs/alternation.md"
     )), BTreeMap::from([(String::from("error"), String::from("An error node"))]))]
-    #[case(SOURCE, vec![], Position { line: 15, character: 18 }, Range {
+    #[case(SOURCE, Position { line: 15, character: 18 }, Range {
         start: Position::new(15, 18),
         end: Position::new(15, 23)
     },
     "Set a property\n\n---\n\n## Parameters:\n\n- Type: `string` (required)\n  - A property\n", BTreeMap::default())]
-    #[case(SOURCE, vec![], Position { line: 15, character: 22 }, Range {
+    #[case(SOURCE, Position { line: 15, character: 22 }, Range {
         start: Position::new(15, 18),
         end: Position::new(15, 23)
     },
     "Set a property\n\n---\n\n## Parameters:\n\n- Type: `string` (required)\n  - A property\n", BTreeMap::default())]
-    #[case(SOURCE, vec![], Position { line: 15, character: 23 }, Range::default(), "", BTreeMap::default())]
-    #[case(SOURCE, vec![], Position { line: 15, character: 21 }, Range {
+    #[case(SOURCE, Position { line: 15, character: 23 }, Range::default(), "", BTreeMap::default())]
+    #[case(SOURCE, Position { line: 15, character: 21 }, Range {
         start: Position::new(15, 18),
         end: Position::new(15, 23)
     },
     "Set a property\n\n---\n\n## Parameters:\n\n- Type: `string` (required)\n  - A property\n", BTreeMap::default())]
-    #[case(SOURCE, vec![], Position { line: 17, character: 12 }, Range {
+    #[case(SOURCE, Position { line: 17, character: 12 }, Range {
         start: Position::new(17, 12),
         end: Position::new(17, 13),
     },
@@ -365,23 +380,23 @@ An error node", BTreeMap::from([(String::from("error"), String::from("An error n
         env!("CARGO_MANIFEST_DIR"),
         "/docs/negation.md"
     )), BTreeMap::default())]
-    #[case(SOURCE, vec![], Position { line: 19, character: 18 }, Range {
+    #[case(SOURCE, Position { line: 19, character: 18 }, Range {
         start: Position::new(19, 18),
         end: Position::new(19, 22)
     },
     "Check for equality\n\n---\n\n## Parameters:\n\n- Type: `capture` (required)\n  - A capture\n- Type: `string` (required)\n  - A string\n", BTreeMap::default())]
-    #[case(";;; inherits: foo", vec![], Position { line: 0, character: 2 }, Range {
+    #[case(";;; inherits: foo", Position { line: 0, character: 2 }, Range {
         start: Position::new(0, 0),
         end: Position::new(0, 17)
     },
     "## Inheriting queries\n\n```query\n; inherits: foo,bar\n```\n\nQueries can inherit other queries if they have an `; inherits:` comment as the\nfirst line of the query file. The language server will then act as though the\ntext of the inherited query files was placed at the top of the document, and\nwill provide diagnostics for the text in those queries as well (calculated with\nthe language information of the parent query). Queries will always inherit\nothers of the same type (e.g. a `highlights.scm` will only import other\n`highlights.scm`, never an `injections.scm`).\n\nNote that the syntax is very sensitive; there must be _exactly one_ space after\nthe `inherits:` keyword, and there must be no spaces in-between module names.\n", BTreeMap::default())]
     #[case("
-;;; inherits: foo", vec![], Position { line: 1, character: 2 }, Range {
+;;; inherits: foo", Position { line: 1, character: 2 }, Range {
         start: Position::new(0, 0),
         end: Position::new(0, 17)
     },
     "", BTreeMap::default())]
-    #[case(";;; format-ignore", vec![], Position { line: 0, character: 2 }, Range {
+    #[case(";;; format-ignore", Position { line: 0, character: 2 }, Range {
         start: Position::new(0, 0),
         end: Position::new(0, 17)
     },
@@ -389,7 +404,6 @@ An error node", BTreeMap::from([(String::from("error"), String::from("An error n
     #[tokio::test(flavor = "current_thread")]
     async fn hover(
         #[case] source: &str,
-        #[case] supertypes: Vec<&str>,
         #[case] position: Position,
         #[case] range: Range,
         #[case] hover_content: &str,
@@ -397,8 +411,7 @@ An error node", BTreeMap::from([(String::from("error"), String::from("An error n
     ) {
         // Arrange
         let mut service = initialize_server(
-            &[(TEST_URI.clone(), source)],
-            &[(String::from("js"), Vec::new(), Vec::new(), supertypes)],
+            &[(QUERY_TEST_URI.clone(), source)],
             &Options {
                 valid_captures: HashMap::from([(String::from("test"), captures)]),
                 valid_predicates: BTreeMap::from([(
@@ -444,7 +457,7 @@ An error node", BTreeMap::from([(String::from("error"), String::from("An error n
                 HoverParams {
                     text_document_position_params: TextDocumentPositionParams {
                         text_document: TextDocumentIdentifier {
-                            uri: TEST_URI.clone(),
+                            uri: QUERY_TEST_URI.clone(),
                         },
                         position,
                     },

--- a/src/handlers/references.rs
+++ b/src/handlers/references.rs
@@ -126,7 +126,7 @@ function: (identifier) @function)",
     ) {
         // Arrange
         let mut service =
-            initialize_server(&[(TEST_URI.clone(), input)], &[], &Default::default()).await;
+            initialize_server(&[(TEST_URI.clone(), input)], &Default::default()).await;
 
         // Act
         let refs = service

--- a/src/handlers/rename.rs
+++ b/src/handlers/rename.rs
@@ -132,7 +132,7 @@ mod test {
     ) {
         // Arrange
         let mut service =
-            initialize_server(&[(TEST_URI.clone(), original)], &[], &Default::default()).await;
+            initialize_server(&[(TEST_URI.clone(), original)], &Default::default()).await;
 
         // Act
         let rename_edits = service

--- a/src/handlers/selection_range.rs
+++ b/src/handlers/selection_range.rs
@@ -106,12 +106,8 @@ mod test {
         #[case] expected_ranges: Option<Vec<Vec<Range>>>,
     ) {
         // Arrange
-        let mut service = initialize_server(
-            &[(TEST_URI.clone(), document_text)],
-            &[],
-            &Default::default(),
-        )
-        .await;
+        let mut service =
+            initialize_server(&[(TEST_URI.clone(), document_text)], &Default::default()).await;
         let expected_selection_ranges = if let Some(ranges_list) = expected_ranges {
             let mut results = Vec::new();
             for ranges in ranges_list {

--- a/src/handlers/semantic_tokens.rs
+++ b/src/handlers/semantic_tokens.rs
@@ -202,7 +202,7 @@ mod test {
     };
 
     use crate::test_helpers::helpers::{
-        TEST_URI, initialize_server, lsp_request_to_jsonrpc_request,
+        QUERY_TEST_URI, initialize_server, lsp_request_to_jsonrpc_request,
         lsp_response_to_jsonrpc_response,
     };
 
@@ -211,32 +211,23 @@ mod test {
         // Arrange
         let source = r"; inherits: c,cuda
 
-(ERROR) @error (supertype) @node (supertype) @node
+(ERROR) @error (definition) @node (definition) @node
 
-(supertype) @node
+(definition) @node
 
 ; Weird
 (MISSING ERROR) @missingerror
 
-(MISSING supertype) @missingsupertype
+(MISSING definition) @missingsupertype
 
 ;;;format-ignore
 (foo)
         ";
-        let mut service = initialize_server(
-            &[(TEST_URI.clone(), source)],
-            &[(
-                String::from("js"),
-                Vec::new(),
-                Vec::new(),
-                vec!["supertype"],
-            )],
-            &Default::default(),
-        )
-        .await;
+        let mut service =
+            initialize_server(&[(QUERY_TEST_URI.clone(), source)], &Default::default()).await;
 
         // Act
-        let tokens = service
+        let actual_tokens = service
             .ready()
             .await
             .unwrap()
@@ -247,7 +238,7 @@ mod test {
                     },
                     work_done_progress_params: WorkDoneProgressParams::default(),
                     text_document: TextDocumentIdentifier {
-                        uri: TEST_URI.clone(),
+                        uri: QUERY_TEST_URI.clone(),
                     },
                 },
             ))
@@ -255,7 +246,7 @@ mod test {
             .unwrap();
 
         // Assert
-        let actual = Some(SemanticTokensResult::Tokens(SemanticTokens {
+        let expected_tokens = Some(SemanticTokensResult::Tokens(SemanticTokens {
             result_id: None,
             data: vec![
                 // ; inherits:
@@ -291,21 +282,21 @@ mod test {
                 SemanticToken {
                     delta_line: 0,
                     delta_start: 15,
-                    length: 9,
+                    length: 10,
                     token_type: 0,
                     token_modifiers_bitset: 0,
                 },
                 SemanticToken {
                     delta_line: 0,
-                    delta_start: 18,
-                    length: 9,
+                    delta_start: 19,
+                    length: 10,
                     token_type: 0,
                     token_modifiers_bitset: 0,
                 },
                 SemanticToken {
                     delta_line: 2,
                     delta_start: 1,
-                    length: 9,
+                    length: 10,
                     token_type: 0,
                     token_modifiers_bitset: 0,
                 },
@@ -319,7 +310,7 @@ mod test {
                 SemanticToken {
                     delta_line: 2,
                     delta_start: 9,
-                    length: 9,
+                    length: 10,
                     token_type: 0,
                     token_modifiers_bitset: 0,
                 },
@@ -334,8 +325,8 @@ mod test {
             ],
         }));
         assert_eq!(
-            tokens,
-            Some(lsp_response_to_jsonrpc_response::<SemanticTokensFullRequest>(actual))
+            Some(lsp_response_to_jsonrpc_response::<SemanticTokensFullRequest>(expected_tokens)),
+            actual_tokens,
         );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -141,7 +141,7 @@ struct DocumentData {
     imported_uris: Vec<ImportedUri>,
 }
 
-#[derive(Clone, Default, Debug)]
+#[derive(Clone, Debug)]
 struct LanguageData {
     name: String,
     symbols_set: HashSet<SymbolInfo>,
@@ -149,8 +149,7 @@ struct LanguageData {
     fields_set: HashSet<String>,
     fields_vec: Vec<String>,
     supertype_map: HashMap<SymbolInfo, BTreeSet<SymbolInfo>>,
-    // Only `None` in test mocks
-    language: Option<Language>,
+    language: Language,
 }
 
 struct Backend {

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -2,32 +2,25 @@
 pub mod helpers {
     use serde_json::to_value;
 
-    use std::{
-        collections::{BTreeSet, HashMap, HashSet},
-        path::PathBuf,
-        str::FromStr,
-        sync::{Arc, LazyLock},
-    };
+    use std::sync::LazyLock;
     use tower::{Service, ServiceExt};
-    use tree_sitter::Parser;
 
-    use dashmap::DashMap;
     use tower_lsp::{
         LspService,
         jsonrpc::{Request, Response},
         lsp_types::{
             ClientCapabilities, DidOpenTextDocumentParams, InitializeParams, Position, Range,
-            TextDocumentContentChangeEvent, TextDocumentItem, TextEdit, Url,
+            TextDocumentContentChangeEvent, TextDocumentItem, TextEdit, Url, WorkspaceFolder,
             notification::DidOpenTextDocument, request::Initialize,
         },
     };
 
-    use crate::{Backend, LanguageData, Options, QUERY_LANGUAGE, SymbolInfo};
+    use crate::{Backend, Options};
 
     pub static TEST_URI: LazyLock<Url> =
         LazyLock::new(|| Url::parse("file:///tmp/queries/js/test.scm").unwrap());
-    pub static TEST_URI_2: LazyLock<Url> =
-        LazyLock::new(|| Url::parse("file:///tmp/queries/css/test.scm").unwrap());
+    pub static QUERY_TEST_URI: LazyLock<Url> =
+        LazyLock::new(|| Url::parse("file:///tmp/queries/query/test.scm").unwrap());
     pub const SIMPLE_FILE: &str = include_str!(concat!(
         env!("CARGO_MANIFEST_DIR"),
         "/queries/example_test_files/simple.scm"
@@ -43,70 +36,22 @@ pub mod helpers {
     /// A tuple holding the document's URI and source text.
     pub type Document<'a> = (Url, &'a str);
 
-    /// A tuple holding the language's name, symbols, fields, and supertype names.
-    pub type TestLanguage<'a> = (String, Vec<SymbolInfo>, Vec<&'a str>, Vec<&'a str>);
-
     /// Initialize a test server, populating it with fake documents denoted by (uri, text, symbols, fields) tuples.
     pub async fn initialize_server(
         documents: &[Document<'_>],
-        languages: &[TestLanguage<'_>],
         options: &Options,
     ) -> LspService<Backend> {
-        let mut parser = Parser::new();
-        parser
-            .set_language(&QUERY_LANGUAGE)
-            .expect("Error loading Query grammar");
         let options_value = serde_json::to_value(options).unwrap();
-        let options = &serde_json::from_value::<Options>(options_value.clone()).unwrap();
-        let arced_options = Arc::new(tokio::sync::RwLock::new(options.clone()));
-        let workspace_dirs = vec![
-            PathBuf::from_str(concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/queries/test_workspace/"
-            ))
-            .unwrap(),
-        ];
         let (mut service, _socket) = LspService::build(|client| Backend {
             _client: client,
             document_map: Default::default(),
-            language_map: DashMap::from_iter(languages.iter().cloned().map(
-                |(name, symbols, fields, supertypes)| {
-                    (
-                        name.clone(),
-                        Arc::new(LanguageData {
-                            name,
-                            symbols_set: HashSet::from_iter(symbols.iter().cloned()),
-                            symbols_vec: symbols.to_vec(),
-                            fields_set: HashSet::from_iter(fields.iter().map(ToString::to_string)),
-                            fields_vec: fields.iter().map(ToString::to_string).collect(),
-                            supertype_map: HashMap::from_iter(supertypes.iter().map(|st| {
-                                (
-                                    SymbolInfo {
-                                        label: st.to_string(),
-                                        named: true,
-                                    },
-                                    BTreeSet::from([
-                                        SymbolInfo {
-                                            label: "test".to_string(),
-                                            named: true,
-                                        },
-                                        SymbolInfo {
-                                            label: "test2".to_string(),
-                                            named: true,
-                                        },
-                                    ]),
-                                )
-                            })),
-                            language: None,
-                        }),
-                    )
-                },
-            )),
-            workspace_uris: Arc::new(workspace_dirs.into()),
-            options: arced_options,
+            language_map: Default::default(),
+            workspace_uris: Default::default(),
+            options: Default::default(),
         })
         .finish();
 
+        // Initialize the server
         service
             .ready()
             .await
@@ -114,7 +59,14 @@ pub mod helpers {
             .call(lsp_request_to_jsonrpc_request::<Initialize>(
                 InitializeParams {
                     capabilities: ClientCapabilities::default(),
-                    root_uri: Some(Url::parse("file:///tmp/").unwrap()),
+                    workspace_folders: Some(vec![WorkspaceFolder {
+                        name: String::from("test_workspace"),
+                        uri: Url::from_file_path(concat!(
+                            env!("CARGO_MANIFEST_DIR"),
+                            "/queries/test_workspace/"
+                        ))
+                        .unwrap(),
+                    }]),
                     initialization_options: Some(options_value),
                     ..Default::default()
                 },
@@ -230,41 +182,26 @@ mod test {
         collections::{BTreeMap, HashMap},
         ops::Deref,
     };
+    use tower_lsp::lsp_types::Url;
     use ts_query_ls::Options;
 
     use pretty_assertions::assert_eq;
     use rstest::rstest;
 
-    use crate::{
-        SymbolInfo,
-        test_helpers::helpers::{
-            COMPLEX_FILE, SIMPLE_FILE, TEST_URI, TEST_URI_2, initialize_server,
-        },
-    };
+    use crate::test_helpers::helpers::{COMPLEX_FILE, SIMPLE_FILE, TEST_URI, initialize_server};
 
-    use super::helpers::{Document, TestLanguage};
+    use super::helpers::Document;
 
     #[rstest]
-    #[case(&[], &[], &Default::default())]
+    #[case(&[], &Default::default())]
     #[case(&[(
             TEST_URI.clone(),
             SIMPLE_FILE,
         ),
         (
-            TEST_URI_2.clone(),
+            Url::parse("file:///tmp/queries/css/test.scm").unwrap(),
             COMPLEX_FILE,
         )],
-        &[
-            (
-                String::from("css"),
-                vec![
-                    SymbolInfo { named: true, label: String::from("identifier") },
-                    SymbolInfo { named: false, label: String::from(";") },
-                ],
-                vec!["operator", "content"],
-                vec!["type"]
-            )
-        ],
         &Options {
             valid_captures: HashMap::from([(String::from("test"), BTreeMap::from([(String::from("variable"), String::from("A common variable"))]))]),
             ..Default::default()
@@ -273,11 +210,10 @@ mod test {
     #[tokio::test(flavor = "current_thread")]
     async fn initialize_server_helper(
         #[case] documents: &[Document<'_>],
-        #[case] languages: &[TestLanguage<'_>],
         #[case] options: &Options,
     ) {
         // Act
-        let service = initialize_server(documents, languages, options).await;
+        let service = initialize_server(documents, options).await;
 
         // Assert
         let backend = service.inner();
@@ -299,27 +235,6 @@ mod test {
                     .unwrap(),
                 (*source).to_string()
             );
-        }
-        for (language_name, symbols, fields, supertypes) in languages {
-            let language_data = backend.language_map.get(language_name).unwrap();
-            assert!(language_data.symbols_vec.len() == symbols.len());
-            assert!(language_data.symbols_set.len() == symbols.len());
-            for symbol in symbols {
-                assert!(language_data.symbols_vec.contains(symbol));
-                assert!(language_data.symbols_set.contains(symbol));
-            }
-            assert!(language_data.fields_vec.len() == fields.len());
-            assert!(language_data.fields_set.len() == fields.len());
-            for field in fields {
-                assert!(language_data.fields_vec.contains(&field.to_string()));
-                assert!(language_data.fields_set.contains(*field));
-            }
-            for supertype in supertypes {
-                assert!(language_data.supertype_map.contains_key(&SymbolInfo {
-                    named: true,
-                    label: String::from(*supertype)
-                }))
-            }
         }
     }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -234,6 +234,11 @@ pub fn get_language_name_raw(path: &Path, options: &Options) -> Option<String> {
 }
 
 pub fn get_language(name: &str, options: &Options) -> Option<Language> {
+    // Return query language object for mock tests
+    if cfg!(test) && name == "query" {
+        return Some(QUERY_LANGUAGE.clone());
+    }
+
     let directories = &options.parser_install_directories;
     let name = name.replace('-', "_");
     let language_fn_name = format!("tree_sitter_{name}");


### PR DESCRIPTION
This allows us to have true end-to-end coverage for language loading, at least just for the `query` language. In the future other languages can be added as dev dependencies.

This allows for another massive refactor of the test logic, removing custom test helper hacks, unnecessary optionals used by mocks, and removes lots of redundant code, replacing it with calls to the actual server method handlers (which now have increased test coverage).