### PR TITLE
feat: specify supported ABI versions in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ its ancestor directories. Below is an example file:
       "variable.parameter": "Parameters of a function"
     }
   },
+  "supported_abi_versions": {
+    "start": 13,
+    "end": 15
+  },
   "valid_predicates": {
     "eq": {
       "parameters": [
@@ -201,6 +205,20 @@ vim.api.nvim_create_autocmd('FileType', {
     }
   end,
 })
+```
+
+#### `supported_abi_versions`
+
+An inclusive range of ABI versions supported by your tool. The end of the range
+must be greater than or equal to the start.
+
+```json
+{
+  "supported_abi_versions": {
+    "start": 13,
+    "end": 15
+  }
+}
 ```
 
 ## Features

--- a/schemas/config.json
+++ b/schemas/config.json
@@ -43,6 +43,17 @@
         "type": "string"
       }
     },
+    "supported_abi_versions": {
+      "description": "An inclusive range of ABI versions supported by your tool. The end of the range must be greater than or equal to the start.",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/Range_of_uint32"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "valid_captures": {
       "description": "A map from query file name to valid captures. Valid captures are represented as a map from capture name (sans `@`) to a short (markdown format) description. Note that captures prefixed with an underscore are always permissible.",
       "default": {},
@@ -230,6 +241,25 @@
           ]
         }
       ]
+    },
+    "Range_of_uint32": {
+      "type": "object",
+      "required": [
+        "end",
+        "start"
+      ],
+      "properties": {
+        "end": {
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0
+        },
+        "start": {
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0
+        }
+      }
     },
     "Regex": {
       "description": "A regular expression string (compiled at deserialization time)",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,29 +114,39 @@ pub struct Options {
     /// Supports environment variable expansion of the form `${VAR}`.
     #[serde(default, deserialize_with = "deserialize_and_expand")]
     pub parser_install_directories: Vec<String>,
+
     /// A map of parser aliases.
     #[serde(default)]
     pub parser_aliases: BTreeMap<String, String>,
+
     /// A list of patterns to aid the LSP in finding a language, given a file path.
     /// Patterns must have one capture group which represents the language name. Ordered
     /// from highest to lowest precedence.
     #[serde(default = "default_regexes", deserialize_with = "add_default_regexes")]
     pub language_retrieval_patterns: Vec<SerializableRegex>,
+
     /// A map from query file name to valid captures. Valid captures are represented as a map from
     /// capture name (sans `@`) to a short (markdown format) description. Note that captures
     /// prefixed with an underscore are always permissible.
     #[serde(default)]
     pub valid_captures: HashMap<String, BTreeMap<String, String>>,
+
     /// A map of predicate names (sans `#` and `?`) to parameter specifications.
     #[serde(default, deserialize_with = "add_prefixes")]
     #[cfg_attr(feature = "schema", schemars(schema_with = "prefixes_schema"))]
     pub valid_predicates: BTreeMap<String, Predicate>,
+
     /// A map of directive names (sans `#` and `!`) to parameter specifications.
     #[serde(default)]
     pub valid_directives: BTreeMap<String, Predicate>,
+
     /// Options related to diagnostics
     #[serde(default)]
     pub diagnostic_options: DiagnosticOptions,
+
+    /// An inclusive range of ABI versions supported by your tool. The end of the range must be
+    /// greater than or equal to the start.
+    pub supported_abi_versions: Option<std::ops::RangeInclusive<u32>>,
 }
 
 #[cfg(feature = "schema")]

--- a/tests/lint.rs
+++ b/tests/lint.rs
@@ -10,11 +10,6 @@ mod test {
     use ts_query_ls::{Options, Predicate, PredicateParameter};
 
     static CONFIG: LazyLock<Options> = LazyLock::new(|| Options {
-        parser_install_directories: Vec::new(),
-        language_retrieval_patterns: Vec::new(),
-        parser_aliases: BTreeMap::new(),
-        diagnostic_options: Default::default(),
-        valid_directives: BTreeMap::new(),
         valid_predicates: BTreeMap::from([
             (
                 String::from("pred-name"),
@@ -49,6 +44,7 @@ mod test {
                 BTreeMap::from([(String::from("type"), String::from("A type."))]),
             ),
         ]),
+        ..Default::default()
     });
 
     #[rstest]


### PR DESCRIPTION
This allows the server to provide diagnostics for unsupported parser ABI versions.

Closes #93 