### PR TITLE
refactor: reduce parser allocations by keeping a static object

### DIFF
--- a/src/cli/lint.rs
+++ b/src/cli/lint.rs
@@ -11,12 +11,12 @@ use tower_lsp::lsp_types::{CodeAction, CodeActionOrCommand, DiagnosticSeverity, 
 use ts_query_ls::Options;
 
 use crate::{
-    DocumentData, LanguageData, QUERY_LANGUAGE,
+    DocumentData, LanguageData,
     handlers::{
         code_action::diag_to_code_action, diagnostic::get_diagnostics,
         did_open::populate_import_documents,
     },
-    util::{edit_rope, get_imported_uris, get_language_name, get_scm_files},
+    util::{edit_rope, get_imported_uris, get_language_name, get_scm_files, parse},
 };
 
 #[allow(clippy::too_many_arguments)] // TODO: Refactor this
@@ -31,14 +31,8 @@ pub(super) async fn lint_file(
     language_data: Option<Arc<LanguageData>>,
     exit_code: &AtomicI32,
 ) -> Option<String> {
-    let mut parser = tree_sitter::Parser::new();
-    parser
-        .set_language(&QUERY_LANGUAGE)
-        .expect("Error loading Query grammar");
-    let tree = parser
-        .parse(source, None)
-        .expect("Parsing should've completed");
     let rope = Rope::from(source);
+    let tree = parse(&rope, None);
     let options_val = options.clone().read().await.clone();
     let language_name = get_language_name(uri, &options_val);
     let workspace_uris = &[workspace.to_owned()];

--- a/src/handlers/document_highlight.rs
+++ b/src/handlers/document_highlight.rs
@@ -4,7 +4,7 @@ use streaming_iterator::StreamingIterator;
 use tower_lsp::jsonrpc::Result;
 use tower_lsp::lsp_types::{DocumentHighlight, DocumentHighlightKind, DocumentHighlightParams};
 use tracing::warn;
-use tree_sitter::{Parser, Query, QueryCursor};
+use tree_sitter::{Query, QueryCursor};
 
 use crate::util::{CAPTURES_QUERY, NodeUtil, TextProviderRope, ToTsPoint, get_references};
 use crate::{Backend, QUERY_LANGUAGE};
@@ -45,11 +45,6 @@ pub async fn document_highlight(
     let ident_query = &IDENT_QUERY;
     let mut cursor = QueryCursor::new();
     let provider = TextProviderRope(rope);
-
-    let mut parser = Parser::new();
-    parser
-        .set_language(&QUERY_LANGUAGE)
-        .expect("Error setting language for Query parser");
 
     if current_node.kind() == "capture" {
         Ok(Some(

--- a/src/handlers/goto_definition.rs
+++ b/src/handlers/goto_definition.rs
@@ -3,10 +3,10 @@ use tower_lsp::{
     lsp_types::{GotoDefinitionParams, GotoDefinitionResponse, Location},
 };
 use tracing::{info, warn};
-use tree_sitter::{Parser, QueryCursor};
+use tree_sitter::QueryCursor;
 
 use crate::{
-    Backend, QUERY_LANGUAGE,
+    Backend,
     util::{
         CAPTURES_QUERY, NodeUtil, TextProviderRope, ToTsPoint, get_current_capture_node,
         get_imported_module_under_cursor, get_references,
@@ -45,11 +45,6 @@ pub async fn goto_definition(
     let query = &CAPTURES_QUERY;
     let mut cursor = QueryCursor::new();
     let provider = TextProviderRope(rope);
-
-    let mut parser = Parser::new();
-    parser
-        .set_language(&QUERY_LANGUAGE)
-        .expect("Error setting language for Query parser");
 
     let defs = get_references(
         &tree.root_node(),

--- a/src/handlers/references.rs
+++ b/src/handlers/references.rs
@@ -1,11 +1,11 @@
 use tower_lsp::jsonrpc::Result;
 use tower_lsp::lsp_types::{Location, ReferenceParams};
 use tracing::warn;
-use tree_sitter::{Parser, QueryCursor};
+use tree_sitter::QueryCursor;
 
 use crate::util::{CAPTURES_QUERY, NodeUtil, ToTsPoint};
 use crate::{
-    Backend, QUERY_LANGUAGE,
+    Backend,
     util::{TextProviderRope, get_current_capture_node, get_references},
 };
 
@@ -31,11 +31,6 @@ pub async fn references(
     let query = &CAPTURES_QUERY;
     let mut cursor = QueryCursor::new();
     let provider = TextProviderRope(rope);
-
-    let mut parser = Parser::new();
-    parser
-        .set_language(&QUERY_LANGUAGE)
-        .expect("Error setting language for Query parser");
 
     Ok(Some(
         get_references(


### PR DESCRIPTION
Also, remove some useless parser instantiations in some handlers that don't need it.