### PR TITLE
fix(cli): remove conflicting `-f` short arg for `check` command

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -324,7 +324,7 @@ enum Commands {
         format: bool,
 
         /// Apply fixes to diagnostics that have them.
-        #[arg(long, short)]
+        #[arg(long)]
         fix: bool,
     },
     /// Lint the query files in the given directories for errors. This differs from `check` because


### PR DESCRIPTION
I ran into the following:

```sh
❯ ts_query_ls check .

thread 'main' panicked at /home/lillis/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/clap_builder-4.5.40/src/builder/debug_asserts.rs:112:17:
Command check: Short option names must be unique for each argument, but '-f' is in use by both 'format' and 'fix'
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

When the `--fix` argument was added the `check` command in 5c57aab, it included the `short` option. This conflicts with the existing `short` option for `--format`. I removed the extra `short` from `--fix` to match the behavior from before, but I'm happy to flip the removal if desired.