### PR TITLE
refactor: store empty version for unopened documents

### DIFF
--- a/src/handlers/did_change.rs
+++ b/src/handlers/did_change.rs
@@ -15,7 +15,7 @@ pub async fn did_change(backend: &Backend, params: DidChangeTextDocumentParams) 
         return;
     };
     let version = params.text_document.version;
-    document.version = version;
+    document.version = Some(version);
 
     let mut edits = vec![];
     let mut recalculate_imports = false;

--- a/src/handlers/did_open.rs
+++ b/src/handlers/did_open.rs
@@ -28,7 +28,7 @@ pub async fn did_open(backend: &Backend, params: DidOpenTextDocumentParams) {
     let imported_uris = get_imported_uris(&workspace_uris, &options, &uri, &rope, &tree);
 
     // Track the document
-    let version = params.text_document.version;
+    let version = Some(params.text_document.version);
     backend.document_map.insert(
         uri.clone(),
         DocumentData {
@@ -169,7 +169,7 @@ pub fn populate_import_documents(
                     rope,
                     tree,
                     language_name: None,
-                    version: -1,
+                    version: None,
                     imported_uris: nested_imported_uris.clone(),
                 },
             );

--- a/src/handlers/rename.rs
+++ b/src/handlers/rename.rs
@@ -69,7 +69,7 @@ pub async fn rename(backend: &Backend, params: RenameParams) -> Result<Option<Wo
         document_changes: Some(DocumentChanges::Edits(vec![TextDocumentEdit {
             text_document: OptionalVersionedTextDocumentIdentifier {
                 uri: uri.clone(),
-                version: Some(doc.version),
+                version: doc.version,
             },
             edits,
         }])),

--- a/src/main.rs
+++ b/src/main.rs
@@ -140,10 +140,16 @@ impl ImportedUri {
 
 #[derive(Clone)]
 struct DocumentData {
+    /// The document's text content.
     rope: Rope,
+    /// The document's parsed CST.
     tree: Tree,
-    version: i32,
+    /// Document version. `None` if the document has not been opened by the editor (i.e., it was
+    /// constructed because an open document imports it).
+    version: Option<i32>,
+    /// The query language name for the document, if it exists.
     language_name: Option<String>,
+    /// The modules imported by this document.
     imported_uris: Vec<ImportedUri>,
 }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -635,12 +635,13 @@ pub async fn push_diagnostics(backend: &Backend, uri: Url) {
         {
             backend
                 .client
-                .publish_diagnostics(uri, full_document_diagnostic_report.items, Some(version))
+                .publish_diagnostics(uri, full_document_diagnostic_report.items, version)
                 .await;
 
             for (uri, report) in related_documents.unwrap_or_default() {
                 if let DocumentDiagnosticReportKind::Full(report) = report
-                    && let Some(version) = backend.document_map.get(&uri).map(|doc| doc.version)
+                    && let Some(version) =
+                        backend.document_map.get(&uri).and_then(|doc| doc.version)
                 {
                     backend
                         .client


### PR DESCRIPTION
Documents which are populated only because other documents have imported them, but have not been opened by the editor itself, should not have a fake -1 sentinel version number. Rather, the number should be `None` for slightly better correctness.