### PR TITLE
feat: work done progress for workspace symbols

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -613,6 +613,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi 0.14.2+wasi-0.2.4",
+]
+
+[[package]]
 name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -960,7 +972,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
 dependencies = [
  "libc",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.59.0",
 ]
 
@@ -1148,6 +1160,12 @@ checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "redox_syscall"
@@ -1794,6 +1812,7 @@ dependencies = [
  "tracing-subscriber",
  "tree-sitter",
  "tree-sitter-query",
+ "uuid",
 ]
 
 [[package]]
@@ -1833,6 +1852,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "uuid"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1859,6 +1887,15 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasi"
+version = "0.14.2+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+dependencies = [
+ "wit-bindgen-rt",
+]
 
 [[package]]
 name = "wasm-encoder"
@@ -2331,6 +2368,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74c7b26e3480b707944fc872477815d29a8e429d2f93a1ce000f5fa84a15cbcd"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+dependencies = [
+ "bitflags 2.9.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ tracing = "0.1.41"
 tracing-subscriber = "0.3.18"
 tree-sitter = { version = "0.25.8", features = ["std", "wasm"] }
 tree-sitter-query = { git = "https://github.com/tree-sitter-grammars/tree-sitter-query", version = "0.6.2" }
+uuid = { version = "1.17.0", features = ["v4"], default-features = false }
 
 [build-dependencies]
 cc = "1.1.30"

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,7 +36,7 @@ use tower_lsp::{
         SemanticTokensParams, SemanticTokensRangeParams, SemanticTokensRangeResult,
         SemanticTokensResult, SemanticTokensServerCapabilities, ServerCapabilities,
         SymbolInformation, TextDocumentSyncCapability, TextDocumentSyncKind, TextEdit, Url,
-        WorkspaceEdit, WorkspaceSymbolParams,
+        WorkDoneProgressOptions, WorkspaceEdit, WorkspaceSymbolOptions, WorkspaceSymbolParams,
     },
 };
 use tree_sitter::{Language, Tree, wasmtime::Engine};
@@ -96,7 +96,12 @@ static SERVER_CAPABILITIES: LazyLock<ServerCapabilities> = LazyLock::new(|| Serv
     hover_provider: Some(HoverProviderCapability::Simple(true)),
     document_symbol_provider: Some(OneOf::Left(true)),
     selection_range_provider: Some(SelectionRangeProviderCapability::Simple(true)),
-    workspace_symbol_provider: Some(OneOf::Left(true)),
+    workspace_symbol_provider: Some(OneOf::Right(WorkspaceSymbolOptions {
+        work_done_progress_options: WorkDoneProgressOptions {
+            work_done_progress: Some(true),
+        },
+        resolve_provider: None,
+    })),
     ..Default::default()
 });
 static ENGINE: LazyLock<Engine> = LazyLock::new(Engine::default);


### PR DESCRIPTION
Reads the token passed via request parameters, or creates one and issues a new work progress request (if the client supports them) when no token was given.