### PR TITLE
test: mock client to record notification events

### DIFF
--- a/src/handlers/code_action.rs
+++ b/src/handlers/code_action.rs
@@ -12,7 +12,7 @@ use tower_lsp::{
 use tree_sitter::{QueryCursor, Tree};
 
 use crate::{
-    Backend,
+    Backend, LspClient,
     util::{
         CAPTURES_QUERY, NodeUtil, PosUtil, RangeUtil, TextProviderRope, get_current_capture_node,
         get_references,
@@ -190,8 +190,8 @@ pub fn diag_to_code_action(
     }
 }
 
-pub async fn code_action(
-    backend: &Backend,
+pub async fn code_action<C: LspClient>(
+    backend: &Backend<C>,
     params: CodeActionParams,
 ) -> Result<Option<CodeActionResponse>> {
     let uri = &params.text_document.uri;

--- a/src/handlers/completion.rs
+++ b/src/handlers/completion.rs
@@ -14,10 +14,10 @@ use crate::util::{
     CAPTURES_QUERY, NodeUtil, PosUtil, TextProviderRope, get_current_capture_node,
     get_language_name_raw, get_scm_files, node_is_or_has_ancestor, uri_to_basename,
 };
-use crate::{Backend, SymbolInfo};
+use crate::{Backend, LspClient, SymbolInfo};
 
-pub async fn completion(
-    backend: &Backend,
+pub async fn completion<C: LspClient>(
+    backend: &Backend<C>,
     params: CompletionParams,
 ) -> Result<Option<CompletionResponse>> {
     let uri = &params.text_document_position.text_document.uri;

--- a/src/handlers/diagnostic.rs
+++ b/src/handlers/diagnostic.rs
@@ -26,7 +26,7 @@ use ts_query_ls::{
 };
 
 use crate::{
-    Backend, DocumentData, ImportedUri, LanguageData, QUERY_LANGUAGE, SymbolInfo,
+    Backend, DocumentData, ImportedUri, LanguageData, LspClient, QUERY_LANGUAGE, SymbolInfo,
     util::{CAPTURES_QUERY, NodeUtil as _, TextProviderRope, uri_to_basename},
 };
 
@@ -147,8 +147,8 @@ pub static IDENTIFIER_REGEX: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"^[a-zA-Z0-9_-][a-zA-Z0-9_.-]*$").unwrap());
 pub static INTEGER_REGEX: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"^-?\d+$").unwrap());
 
-pub async fn diagnostic(
-    backend: &Backend,
+pub async fn diagnostic<C: LspClient>(
+    backend: &Backend<C>,
     params: DocumentDiagnosticParams,
 ) -> Result<DocumentDiagnosticReportResult> {
     let uri = &params.text_document.uri;
@@ -184,8 +184,8 @@ pub async fn diagnostic(
 static QUERY_SCAN_CACHE: LazyLock<DashMap<(String, String), Option<usize>>> =
     LazyLock::new(DashMap::new);
 
-async fn create_diagnostic_report(
-    backend: &Backend,
+async fn create_diagnostic_report<C: LspClient>(
+    backend: &Backend<C>,
     document: DocumentData,
     uri: &Url,
 ) -> FullDocumentDiagnosticReport {
@@ -215,10 +215,10 @@ async fn create_diagnostic_report(
     }
 }
 
-async fn add_related_diagnostics(
+async fn add_related_diagnostics<C: LspClient>(
     related_documents: &mut HashMap<Url, DocumentDiagnosticReportKind>,
     seen: &mut HashSet<Url>,
-    backend: &Backend,
+    backend: &Backend<C>,
     uri: &Url,
 ) {
     let deps = backend

--- a/src/handlers/did_change.rs
+++ b/src/handlers/did_change.rs
@@ -2,13 +2,13 @@ use tower_lsp::lsp_types::{DidChangeTextDocumentParams, Position, Range};
 use tracing::warn;
 
 use crate::{
-    Backend,
+    Backend, LspClient,
     util::{ByteUtil, TextDocChangeUtil, edit_rope, get_imported_uris, parse, push_diagnostics},
 };
 
 use super::did_open::populate_import_documents;
 
-pub async fn did_change(backend: &Backend, params: DidChangeTextDocumentParams) {
+pub async fn did_change<C: LspClient>(backend: &Backend<C>, params: DidChangeTextDocumentParams) {
     let uri = params.text_document.uri;
     let Some(mut document) = backend.document_map.get_mut(&uri) else {
         warn!("No document found for URI: {uri} when handling did_change");
@@ -166,5 +166,6 @@ mod test {
             tree.root_node().utf8_text(expected.as_bytes()).unwrap(),
             expected
         );
+        assert_eq!(2, service.inner().client.get_notifications().len());
     }
 }

--- a/src/handlers/did_change_configuration.rs
+++ b/src/handlers/did_change_configuration.rs
@@ -1,8 +1,11 @@
 use tower_lsp::lsp_types::DidChangeConfigurationParams;
 
-use crate::{Backend, util::set_configuration_options};
+use crate::{Backend, LspClient, util::set_configuration_options};
 
-pub async fn did_change_configuration(backend: &Backend, params: DidChangeConfigurationParams) {
+pub async fn did_change_configuration<C: LspClient>(
+    backend: &Backend<C>,
+    params: DidChangeConfigurationParams,
+) {
     set_configuration_options(
         backend,
         Some(params.settings),

--- a/src/handlers/did_close.rs
+++ b/src/handlers/did_close.rs
@@ -1,9 +1,9 @@
 use tower_lsp::lsp_types::DidCloseTextDocumentParams;
 use tracing::{info, warn};
 
-use crate::Backend;
+use crate::{Backend, LspClient};
 
-pub async fn did_close(backend: &Backend, params: DidCloseTextDocumentParams) {
+pub async fn did_close<C: LspClient>(backend: &Backend<C>, params: DidCloseTextDocumentParams) {
     let uri = &params.text_document.uri;
     info!("ts_query_ls did_close: {uri}");
     if backend.document_map.remove(uri).is_none() {

--- a/src/handlers/did_save.rs
+++ b/src/handlers/did_save.rs
@@ -1,9 +1,9 @@
 use tower_lsp::lsp_types::DidSaveTextDocumentParams;
 use tracing::info;
 
-use crate::Backend;
+use crate::{Backend, LspClient};
 
-pub async fn did_save(_: &Backend, params: DidSaveTextDocumentParams) {
+pub async fn did_save<C: LspClient>(_: &Backend<C>, params: DidSaveTextDocumentParams) {
     let uri = params.text_document.uri;
     info!("ts_query_ls saved document with URI: {uri}");
 }

--- a/src/handlers/document_highlight.rs
+++ b/src/handlers/document_highlight.rs
@@ -7,13 +7,13 @@ use tracing::warn;
 use tree_sitter::{Query, QueryCursor};
 
 use crate::util::{CAPTURES_QUERY, NodeUtil, PosUtil, TextProviderRope, get_references};
-use crate::{Backend, QUERY_LANGUAGE};
+use crate::{Backend, LspClient, QUERY_LANGUAGE};
 
 static IDENT_QUERY: LazyLock<Query> =
     LazyLock::new(|| Query::new(&QUERY_LANGUAGE, "(identifier) @name").unwrap());
 
-pub async fn document_highlight(
-    backend: &Backend,
+pub async fn document_highlight<C: LspClient>(
+    backend: &Backend<C>,
     params: DocumentHighlightParams,
 ) -> Result<Option<Vec<DocumentHighlight>>> {
     let uri = &params.text_document_position_params.text_document.uri;

--- a/src/handlers/document_symbol.rs
+++ b/src/handlers/document_symbol.rs
@@ -6,12 +6,12 @@ use tracing::warn;
 use tree_sitter::{QueryCursor, StreamingIterator};
 
 use crate::{
-    Backend,
+    Backend, LspClient,
     util::{CAPTURES_QUERY, NodeUtil, TextProviderRope},
 };
 
-pub async fn document_symbol(
-    backend: &Backend,
+pub async fn document_symbol<C: LspClient>(
+    backend: &Backend<C>,
     params: DocumentSymbolParams,
 ) -> Result<Option<DocumentSymbolResponse>> {
     let uri = &params.text_document.uri;

--- a/src/handlers/formatting.rs
+++ b/src/handlers/formatting.rs
@@ -13,12 +13,12 @@ use tree_sitter::{
     Node, Query, QueryCursor, QueryMatch, QueryPredicateArg, StreamingIterator as _, TreeCursor,
 };
 
-use crate::Backend;
 use crate::QUERY_LANGUAGE;
 use crate::util::{ByteUtil, NodeUtil as _, TextProviderRope};
+use crate::{Backend, LspClient};
 
-pub async fn formatting(
-    backend: &Backend,
+pub async fn formatting<C: LspClient>(
+    backend: &Backend<C>,
     params: DocumentFormattingParams,
 ) -> Result<Option<Vec<TextEdit>>> {
     let uri = &params.text_document.uri;
@@ -34,8 +34,8 @@ pub async fn formatting(
     }))
 }
 
-pub async fn range_formatting(
-    backend: &Backend,
+pub async fn range_formatting<C: LspClient>(
+    backend: &Backend<C>,
     params: DocumentRangeFormattingParams,
 ) -> Result<Option<Vec<TextEdit>>> {
     let uri = &params.text_document.uri;

--- a/src/handlers/goto_definition.rs
+++ b/src/handlers/goto_definition.rs
@@ -6,15 +6,15 @@ use tracing::{info, warn};
 use tree_sitter::QueryCursor;
 
 use crate::{
-    Backend,
+    Backend, LspClient,
     util::{
         CAPTURES_QUERY, NodeUtil, PosUtil, TextProviderRope, get_current_capture_node,
         get_imported_module_under_cursor, get_references,
     },
 };
 
-pub async fn goto_definition(
-    backend: &Backend,
+pub async fn goto_definition<C: LspClient>(
+    backend: &Backend<C>,
     params: GotoDefinitionParams,
 ) -> Result<Option<GotoDefinitionResponse>> {
     info!("ts_query_ls goto_definition: {params:?}");

--- a/src/handlers/hover.rs
+++ b/src/handlers/hover.rs
@@ -9,7 +9,7 @@ use tree_sitter::Query;
 use ts_query_ls::{ParameterConstraint, PredicateParameterType};
 
 use crate::{
-    Backend, QUERY_LANGUAGE, SymbolInfo,
+    Backend, LspClient, QUERY_LANGUAGE, SymbolInfo,
     util::{
         FORMAT_IGNORE_REGEX, INHERITS_REGEX, NodeUtil, PosUtil, capture_at_pos,
         get_imported_module_under_cursor, uri_to_basename,
@@ -50,7 +50,10 @@ static DOCS: LazyLock<HashMap<&'static str, &'static str>> = include_docs_map!(
     "format-ignore",
 );
 
-pub async fn hover(backend: &Backend, params: HoverParams) -> Result<Option<Hover>> {
+pub async fn hover<C: LspClient>(
+    backend: &Backend<C>,
+    params: HoverParams,
+) -> Result<Option<Hover>> {
     let uri = &params.text_document_position_params.text_document.uri;
     let position = params.text_document_position_params.position;
     let options = backend.options.read().await;

--- a/src/handlers/references.rs
+++ b/src/handlers/references.rs
@@ -3,14 +3,15 @@ use tower_lsp::lsp_types::{Location, ReferenceParams};
 use tracing::warn;
 use tree_sitter::QueryCursor;
 
+use crate::LspClient;
 use crate::util::{CAPTURES_QUERY, NodeUtil, PosUtil};
 use crate::{
     Backend,
     util::{TextProviderRope, get_current_capture_node, get_references},
 };
 
-pub async fn references(
-    backend: &Backend,
+pub async fn references<C: LspClient>(
+    backend: &Backend<C>,
     params: ReferenceParams,
 ) -> Result<Option<Vec<Location>>> {
     let uri = &params.text_document_position.text_document.uri;

--- a/src/handlers/rename.rs
+++ b/src/handlers/rename.rs
@@ -9,7 +9,7 @@ use tracing::warn;
 use tree_sitter::QueryCursor;
 
 use crate::{
-    Backend,
+    Backend, LspClient,
     util::{
         CAPTURES_QUERY, NodeUtil, PosUtil, TextProviderRope, get_current_capture_node,
         get_references,
@@ -18,7 +18,10 @@ use crate::{
 
 use super::diagnostic::IDENTIFIER_REGEX;
 
-pub async fn rename(backend: &Backend, params: RenameParams) -> Result<Option<WorkspaceEdit>> {
+pub async fn rename<C: LspClient>(
+    backend: &Backend<C>,
+    params: RenameParams,
+) -> Result<Option<WorkspaceEdit>> {
     let uri = &params.text_document_position.text_document.uri;
     let Some(doc) = backend.document_map.get(uri) else {
         warn!("No document found for URI: {uri} when handling rename");

--- a/src/handlers/selection_range.rs
+++ b/src/handlers/selection_range.rs
@@ -5,12 +5,12 @@ use tower_lsp::{
 use tracing::warn;
 
 use crate::{
-    Backend,
+    Backend, LspClient,
     util::{NodeUtil, PosUtil},
 };
 
-pub async fn selection_range(
-    backend: &Backend,
+pub async fn selection_range<C: LspClient>(
+    backend: &Backend<C>,
     params: SelectionRangeParams,
 ) -> Result<Option<Vec<SelectionRange>>> {
     let uri = params.text_document.uri;

--- a/src/handlers/semantic_tokens.rs
+++ b/src/handlers/semantic_tokens.rs
@@ -11,7 +11,7 @@ use tracing::warn;
 use tree_sitter::{Query, QueryCursor, StreamingIterator};
 
 use crate::{
-    Backend, QUERY_LANGUAGE, SymbolInfo,
+    Backend, LspClient, QUERY_LANGUAGE, SymbolInfo,
     util::{FORMAT_IGNORE_REGEX, INHERITS_REGEX, NodeUtil, PosUtil, TextProviderRope},
 };
 
@@ -26,8 +26,8 @@ static SEM_TOK_QUERY: LazyLock<Query> = LazyLock::new(|| {
     .unwrap()
 });
 
-pub async fn semantic_tokens_full(
-    backend: &Backend,
+pub async fn semantic_tokens_full<C: LspClient>(
+    backend: &Backend<C>,
     params: SemanticTokensParams,
 ) -> Result<Option<SemanticTokensResult>> {
     Ok(get_semantic_tokens(backend, params.text_document.uri, None)
@@ -35,8 +35,8 @@ pub async fn semantic_tokens_full(
         .map(Into::into))
 }
 
-pub async fn semantic_tokens_range(
-    backend: &Backend,
+pub async fn semantic_tokens_range<C: LspClient>(
+    backend: &Backend<C>,
     params: SemanticTokensRangeParams,
 ) -> Result<Option<SemanticTokensRangeResult>> {
     Ok(
@@ -46,8 +46,8 @@ pub async fn semantic_tokens_range(
     )
 }
 
-async fn get_semantic_tokens(
-    backend: &Backend,
+async fn get_semantic_tokens<C: LspClient>(
+    backend: &Backend<C>,
     uri: Url,
     range: Option<Range>,
 ) -> Option<SemanticTokens> {

--- a/src/handlers/shutdown.rs
+++ b/src/handlers/shutdown.rs
@@ -1,9 +1,9 @@
 use tower_lsp::jsonrpc::Result;
 use tracing::info;
 
-use crate::Backend;
+use crate::{Backend, LspClient};
 
-pub async fn shutdown(_backend: &Backend) -> Result<()> {
+pub async fn shutdown<C: LspClient>(_backend: &Backend<C>) -> Result<()> {
     info!("ts_query_ls shutdown");
     Ok(())
 }


### PR DESCRIPTION
We can now test that the server sent certain notifications/requests to the client. Also prevents tests from hanging upon notifying the client. Great!