### PR TITLE
chore: allow building with warnings, for debugging

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,6 @@ members = [
 [lints]
 workspace = true
 
-[workspace.lints.rust]
-warnings = "deny"
-
 [workspace.lints.clippy]
 dbg_macro = "deny"
 todo = "deny"


### PR DESCRIPTION
Is this safe @WillLillis ? Don't want to accidentally mess clippy up, just want to be able to `cargo build` with warnings