### PR TITLE
ci: fix crates.io publish run

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,5 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@1.88.0
-      - uses: katyo/publish-crates@v2
-        with:
-          registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+      - name: Publish to crates.io
+        run: cargo publish --package ts_query_ls --token ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION

The imported workflow thinks `xtask` is a crate for some reason. `cargo publish` seems to recognize that it is not, so I'm not sure where this is coming from. Opting to just publish from the CLI, since we don't need any crazy features.